### PR TITLE
CASMINST-2986: Fix handling of option defaults

### DIFF
--- a/src/server/cray/cfs/api/controllers/options.py
+++ b/src/server/cray/cfs/api/controllers/options.py
@@ -134,6 +134,7 @@ class Options():
             if default is not None:
                 LOGGER.warning(
                     'Option {} has not been initialized.  Defaulting to {}'.format(key, default))
+                return default
             else:
                 LOGGER.error('Option {} has not been initialized.'.format(key))
                 raise e


### PR DESCRIPTION
### Summary and Scope

Fixes cases where options are not initialized before they are needed.  Options are initialized by the services that are most responsible for them, and in two instances this leaves the cfs-api open to needing access to an option before the other service has started.  This can only happen at install time.

### Issues and Related PRs

* Resolves CASMINST-2986

### Testing

Tested on:

* Locally

Tested the function locally, and confirmed that this fix was tested previously for CASMCMS-7399, but this line was left out of the final PR, probably because that change was made during testing and was never pushed.  Also, the logs from the error do show this code path was taken. 

### Risks and Mitigations

None