### PR TITLE
CASMCMS-7445: Change to non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,8 @@ COPY src/server/cray/cfs/api/__main__.py \
 FROM base as application
 ENV PYTHONPATH "/app/lib/server"
 WORKDIR /app/
-EXPOSE 80
+EXPOSE 9000
 RUN apk add --no-cache uwsgi-python3
 COPY config/uwsgi.ini ./
+USER nobody:nobody
 ENTRYPOINT ["uwsgi", "--ini", "/app/uwsgi.ini"]

--- a/config/autogen-server.json
+++ b/config/autogen-server.json
@@ -1,5 +1,5 @@
 {
   "packageVersion": "0.6.0",
   "packageName": "cray.cfs.api",
-  "serverPort": 80
+  "serverPort": 9000
 }

--- a/config/uwsgi.ini
+++ b/config/uwsgi.ini
@@ -1,7 +1,7 @@
 # UWSGI configuration for the Cray Package Repository Service
 [uwsgi]
 plugin=python3
-http-socket=:80
+http-socket=:9000
 master=true
 vacuum=true
 die-on-term=true

--- a/kubernetes/cray-cfs-api/requirements.lock
+++ b/kubernetes/cray-cfs-api/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cray-service
-  repository: http://helmrepo.dev.cray.com:8080
-  version: 1.4.0-20200408175655+ff227be
-digest: sha256:7fd613148b375aeaea457ae88b8d7591d3c8ca9bf97a3f3b1c8c1452af067663
-generated: "2020-04-15T13:05:06.986157-05:00"
+  repository: https://artifactory.algol60.net/artifactory/csm-helm-charts/
+  version: 4.0.0
+digest: sha256:6b204b9fe183480ff5e2f5c56069e7765fa918652cf3c863cc13c2548d28b03c
+generated: "2021-09-10T10:53:50.10629-07:00"

--- a/kubernetes/cray-cfs-api/requirements.yaml
+++ b/kubernetes/cray-cfs-api/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: cray-service
-  version: "^2.0.0"
-  repository: "@cray-internal"
+  version: "^4.0.0"
+  repository: "@cray-algol60"

--- a/kubernetes/cray-cfs-api/values.yaml
+++ b/kubernetes/cray-cfs-api/values.yaml
@@ -35,12 +35,12 @@ cray-service:
               key: vcs_password
       ports:
         - name: http
-          containerPort: 80
+          containerPort: 9000
           protocol: TCP
       readinessProbe:
         httpGet:
           path: /healthz
-          port: 80
+          port: 9000
           scheme: HTTP
         initialDelaySeconds: 60
         periodSeconds: 10
@@ -48,7 +48,7 @@ cray-service:
       livenessProbe:
         httpGet:
           path: /healthz
-          port: 80
+          port: 9000
           scheme: HTTP
         initialDelaySeconds: 60
         periodSeconds: 20

--- a/src/server/cray/cfs/api/__main__.py
+++ b/src/server/cray/cfs/api/__main__.py
@@ -41,7 +41,6 @@ def create_app():
     logging.basicConfig(level=logging.INFO)
     sessions._init()
     options._init()
-    configurations._init()
 
     LOGGER.info("Starting Configuration Framework Service API server")
     app = connexion.App(__name__, specification_dir='./openapi/')

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -35,18 +35,6 @@ DB = dbutils.get_wrapper(db='configurations')
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
-def _init():
-    """ Initialize the credentials field of the git config """
-    credentials_command = 'git config --global credential.helper store'.split()
-    try:
-        subprocess.check_call(credentials_command,
-                              stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        LOGGER.info('Set git credential.helper store')
-    except subprocess.CalledProcessError as e:
-        LOGGER.error('Failed setting git credential.helper store')
-        raise
-
-
 @dbutils.redis_error_handler
 def get_configurations(in_use=None):
     """Used by the GET /configurations API operation"""
@@ -194,6 +182,8 @@ def _get_commit_id(repo_url, branch):
         repo_name = repo_url.split('/')[-1].split('.')[0]
         repo_dir = os.path.join(tmp_dir, repo_name)
 
+        if 'https://api-gw-service-nmn.local/vcs' in repo_url:
+            repo_url = repo_url.replace('https://api-gw-service-nmn.local/vcs', 'http://gitea-vcs')
         split_url = repo_url.split('/')
         username = os.environ['VCS_USERNAME']
         password = os.environ['VCS_PASSWORD']


### PR DESCRIPTION
### Summary and Scope

Updates the cfs-api to use a non-root user.  Includes the following changes:
* Update the image to use a non-root user by default
* Updates the base chart to pull in non-root user changes
* Change to using a non-protected port
* Fixes an issue converting branches to commits that was also preventing the pod from initializing as a non-root user

### Issues and Related PRs

* Resolves CASMCMS-7445

### Testing

Tested on:

* Wasp

Tested upgrading an existing deployment, confirming the cfs-api worked with both read and write, confirming that old data was still accessible, and confirming that branch to commit conversion worked.

### Risks and Mitigations

None