### PR TITLE
CASMCMS-7624: Add clearing of error count when state is cleared

### DIFF
--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -232,7 +232,8 @@ def delete_component(component_id):
 
 def _set_auto_fields(data):
     data = _set_last_updated(data)
-    if ('desiredState' in data or 'desiredConfig' in data) and 'errorCount' not in data:
+    if ('desiredState' in data or 'desiredConfig' in data or data.get('state') == [])\
+            and 'errorCount' not in data:
         data['errorCount'] = 0
     return data
 


### PR DESCRIPTION
### Summary and Scope

The error count for a components will now reset when the state is cleared.  This will avoid confusions in situations where the state is cleared to trigger reconfiguration, including when the cfs-state-reporter clears the state for a rebooted node.  Previously it was possible to reboot a node and leave it in a "failed" state with no reports attempts at configuration.

There is no current use-case for clearing the state without also wanting the error count cleared, but if this does arise in the future, it is still possible to specify the error count while clearing the state. 

### Issues and Related PRs

* Resolves CASMCMS-7624

### Testing

Tested on:

* Mug

Cleared the state to trigger clearing the error count, and made other update calls to components to ensure error count was not always reset.  Also allowed retries to happen until error count maxed out normally.

### Risks and Mitigations

None