### PR TITLE
CASMCMS-7784: Add Ansible passthrough parameter

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -705,6 +705,14 @@ components:
                 The verbose mode to use in the call to the ansible-playbook command. 1 = -v,
                 2 = -vv, etc. Valid values range from 0 to 4. See the ansible-playbook help
                 for more information.
+            passthrough:
+              type: string
+              description: >-
+                Additional parameters that are added to all Ansible calls for the session. This field is
+                currently limited to the following Ansible parameters: "--extra-vars", "--forks",
+                "--skip-tags", "--start-at-task", and "--tags". WARNING: Parameters passed to Ansible in
+                this way should be used with caution.  State will not be recorded for components when
+                using these flags to avoid incorrect reporting of partial playbook runs.
         target:
           $ref: '#/components/schemas/TargetSpecSection'
         status:
@@ -823,6 +831,14 @@ components:
             The verbose mode to use in the call to the ansible-playbook command. 1 = -v,
             2 = -vv, etc. Valid values range from 0 to 4. See the ansible-playbook help
             for more information.
+        ansiblePassthrough:
+          type: string
+          description: >-
+            Additional parameters that are added to all Ansible calls for the session. This field is
+            currently limited to the following Ansible parameters: "--extra-vars", "--forks",
+            "--skip-tags", "--start-at-task", and "--tags". WARNING: Parameters passed to Ansible in
+            this way should be used with caution.  State will not be recorded for components when
+            using these flags to avoid incorrect reporting of partial playbook runs.
         target:
           $ref: '#/components/schemas/TargetSpecSection'
         tags:

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -1,4 +1,7 @@
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -12,13 +15,11 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-#
-# (MIT License)
 
 import connexion
 from copy import deepcopy
@@ -242,7 +243,7 @@ def _set_last_updated(data):
     if 'state' in data and type(data['state']) == list:
         for layer in data['state']:
             if 'lastUpdated' not in layer:
-                layer['lastUpdated'] == datetime.now().strftime(TIME_FORMAT)
+                layer['lastUpdated'] = datetime.now().strftime(TIME_FORMAT)
     if 'desiredState' in data and type(data['desiredState']) == dict:
         data['desiredState']['lastUpdated'] = datetime.now().strftime(TIME_FORMAT)
     return data


### PR DESCRIPTION
## Summary and Scope

Adds a parameter to CFS to allow sessions to be created with arbitrary arguments passed to Ansible

## Issues and Related PRs

* Resolves CASMCMS-7784

## Testing

### Tested on:

  * Wasp

### Test description:

Ran CFS sessions without passthrough parameters, and with different combinations of parameters.

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

