### PR TITLE
CASMINST-3913: Add pod antiaffinity

### DIFF
--- a/kubernetes/cray-cfs-api/values.yaml
+++ b/kubernetes/cray-cfs-api/values.yaml
@@ -61,6 +61,18 @@ cray-service:
         limits:
           memory: "250Mi"
           cpu: "500m"
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - cray-cfs-api
   ingress:
     ui: false
     enabled: true


### PR DESCRIPTION
## Summary and Scope

Adds anit-affinity to the CFS api pods.  CFS uses an autoscaler to determine the number of pods, so the anti-affinity is "preferred" not "required" so that scaling isn't capped by the number of nodes.

## Issues and Related PRs

* Resolves CASMINST-3913

## Testing

### Tested on:

  * Hela

### Test description:

- Deployed with multiple pods and confirmed that they were on different nodes.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

