### PR TITLE
CASMCMS-7823 - Update redis image to alpine:3.15 base image to resolve security issues.

### DIFF
--- a/kubernetes/cray-cfs-api/values.yaml
+++ b/kubernetes/cray-cfs-api/values.yaml
@@ -90,4 +90,4 @@ cray-service:
 database:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis
-    tag: 5.0-alpine3.12
+    tag: 5.0-alpine


### PR DESCRIPTION
## Summary and Scope

Update the database image from redis:5.0-alpine3.12 to redis:5.0-alpine.  This less specific tag allows use of more recent alpine base images that are still being patched for security vulnerabilities.  The current version uses alpine:3.15 and has the security issues resolved.

## Issues and Related PRs
* Resolves [CASMCMS-7823](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7823)
* Change will also be needed in `cray-bos`
* Merge with `https://github.com/Cray-HPE/bos/pull/30`

## Testing
### Tested on:
  * `Mug`
  * Local development environment

### Test description:

I verified the new image is clean using the SNYK scanner.  After building a new version of cray-cfs-api using the new database image, I updated the deployment on Mug, verified the db was working correctly, then rolled back to the original version.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a fairly low risk change as there is nothing in the code that has changed, just the image version that is running the db.  The testing verified the db is functioning as expected.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

