### PR TITLE
CASMCMS-7945: Fix component tag cleanup

### DIFF
--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -354,9 +354,11 @@ def _update_handler(data):
 
 def _tag_cleanup_handler(data):
     tags = data.get('tags', {})
+    clean_tags = {}
     for k, v in tags.items():
-        if v == '':
-            del tags[k]
+        if v:
+            clean_tags[k] = v
+    data['tags'] = clean_tags
     return data
 
 


### PR DESCRIPTION
## Summary and Scope

Fixes an issue with tag cleanup that was affecting BOS v2 in rare cases

## Issues and Related PRs

* Resolves CASMCMS-7945

## Testing

### Tested on:

  * Mug

### Test description:

Deployed the fix with BOS v2 and confirmed that the tag cleanup was working correctly when triggered by BOS.  Also tested manually.

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

