### PR TITLE
Casmcms 7965

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN /usr/local/bin/docker-entrypoint.sh generate \
     -c config/autogen-server.json
 
 # Base image
-FROM artifactory.algol60.net/docker.io/alpine:3.15 as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as base
 WORKDIR /app
 COPY --from=codegen /app .
 COPY constraints.txt requirements.txt ./

--- a/kubernetes/cray-cfs-api/Chart.yaml
+++ b/kubernetes/cray-cfs-api/Chart.yaml
@@ -39,13 +39,11 @@ dependencies:
 maintainers:
 - name: rbak-hpe
   email: ryan.bak@hpe.com
-- name: rkleinman-hpe
-  email: randy.kleinman@hpe.com
 appVersion: 0.0.0
 annotations:
   artifacthub.io/images: |
     - name: cray-cfs
       image: artifactory.algol60.net/csm-docker/stable/cray-cfs:0.0.0
     - name: redis
-      image: docker.io/library/redis:5.0-alpine3.14
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis:5.0-alpine
   artifacthub.io/license: MIT


### PR DESCRIPTION
## Summary and Scope
Change the chart annotations to match the actual redis image used.  This impacts the images that are packaged in a release and what is scanned for CVE vulnerabilities.  It does not impact the actual use of the service.

I have also changed the location of the alpine base image to use the one that is being patched nightly for CVE remediations.  This is the same image, just a different location and will automatically incorporate new security fixes.

## Issues and Related PRs
* Resolves [CASMCMS-7965](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7965)

## Testing
### Tested on:
  * `Wasp`

### Test description:
Installed the new version with loftsman, ran the ct tests (successfully), reverted back to the original install, then re-ran the ct tests to insure everything is still working correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
This is low risk as it is just changing the location the base image is pulled from and modifying helm chart annoations.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

