### PR TITLE
CASMCMS-7965 - Fix chart annotation for version of redis image being used.

### DIFF
--- a/kubernetes/cray-cfs-api/Chart.yaml
+++ b/kubernetes/cray-cfs-api/Chart.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: v2
 name: cray-cfs-api
 version: 0.0.0
@@ -24,5 +47,5 @@ annotations:
     - name: cray-cfs
       image: artifactory.algol60.net/csm-docker/stable/cray-cfs:0.0.0
     - name: redis
-      image: docker.io/library/redis:5.0-alpine3.14
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis:5.0-alpine
   artifacthub.io/license: MIT


### PR DESCRIPTION
## Summary and Scope

Change the chart annotations to match the actual redis image used. This impacts the images that are packaged in a release and what is scanned for CVE vulnerabilities. It does not impact the actual use of the service.

## Issues and Related PRs
* Resolves [CASMCMS-7965](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7965)

## Testing
### Tested on:
  * `Wasp`

### Test description:

Installed the new version with loftsman, ran the ct tests (successfully), reverted back to the original install, then re-ran the ct tests to insure everything is still working correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is low risk as it is just  modifying helm chart annoations.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

