### PR TITLE
CASMCMS-7971 - update dev.cray.com addresses.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ RUN apk add --upgrade --no-cache apk-tools &&  \
 	apk update && \
 	apk add --no-cache gcc python3-dev py3-pip musl-dev libffi-dev openssl-dev git && \
 	apk -U upgrade --no-cache && \
-    PIP_INDEX_URL=https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple \
     pip3 install --no-cache-dir -U pip && \
     pip3 install --no-cache-dir -U 'setuptools<46.0.0' && \
     pip3 install --no-cache-dir -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
 -c constraints.txt
 -r lib/server/requirements.txt
 


### PR DESCRIPTION
## Summary and Scope

The 'dev.cray.com' domain is being retired and the servers moved to hpe domains.  This PR removes references to servers on this domain where able, and updates to the new hpe addresses where we still need to reference internal servers.  There are no real code changes - should just be pulling the same packages from different locations.

## Issues and Related PRs
* Resolves [CASMCMS-7971](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7971)

## Testing
### Tested on:
  * `Mug`

### Test description:

The new versions of all services are installed on Mug and are being left in place while Jason does Bos v2 testing to give these a complete workout.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N - left in place for 'soak' testing
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be low risk as it is just pulling the same stuff from different server addresses.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [x] Testing is appropriate and complete, if applicable
