### PR TITLE
add override for PVC storage class in cray-cfs-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.11.0] - 2022-07-27
 ### Added
+- cray-cfs-api PVC storage class overrides
 - Conversion of repository to gitflow

--- a/kubernetes/cray-cfs-api/templates/database.yaml
+++ b/kubernetes/cray-cfs-api/templates/database.yaml
@@ -29,9 +29,9 @@ metadata:
   name: cfs-db
   namespace: services
 spec:
-  storageClassName: ceph-cephfs-external
+  storageClassName: "{{ .Values.database.storageClass}}"
   accessModes:
-    - ReadWriteMany
+    - "{{ .Values.database.accessMode}}"
   resources:
     requests:
       storage: 3Gi

--- a/kubernetes/cray-cfs-api/values.yaml
+++ b/kubernetes/cray-cfs-api/values.yaml
@@ -114,3 +114,5 @@ database:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis
     tag: 5.0-alpine
+  storageClass: ceph-cephfs-external
+  accessMode: ReadWriteMany


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
The cray-cfs-api chart does not have overrides for the PVC storage class so the override was added. This is a bug fix

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Can helm rollback.
## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link) https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7863


## Testing

_List the environments in which these changes were tested._

### Tested on:
Mug

### Test description:
Ran helm deploy with updated image and template
_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Not sure
- Were continuous integration tests run? If not, why? No 
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
None that I know of
## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

