### PR TITLE
CASMTRIAGE-3835: Escalate pod priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.11.1] - 8/18/22
+### Fixed
+- Escalated pod priority so that configuration has a better chance of running when a node is cordoned
 
 ## [1.11.0] - 2022-07-27
 ### Added

--- a/kubernetes/cray-cfs-api/templates/database.yaml
+++ b/kubernetes/cray-cfs-api/templates/database.yaml
@@ -96,6 +96,7 @@ spec:
       - name: cfs-db
         persistentVolumeClaim:
           claimName: cfs-db
+      priorityClassName: csm-high-priority-service
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/cray-cfs-api/values.yaml
+++ b/kubernetes/cray-cfs-api/values.yaml
@@ -34,6 +34,7 @@ cray-service:
   type: Deployment
   nameOverride: cray-cfs-api
   serviceAccountName: cray-cfs
+  priorityClassName: csm-high-priority-service
   containers:
     cray-cfs-api:
       name: cray-cfs-api


### PR DESCRIPTION
## Summary and Scope

Escalates the pods to a high priority to improve CFS' ability to run when the system is partially down.

## Issues and Related PRs

* Resolves CASMTRIAGE-3835

## Testing

### Tested on:

  * Mug

### Test description:

Deployed the new image chart and tested basic functions

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

