### PR TITLE
CASMCMS-8252: Update Chart with correct image and chart version strings during builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Spelling corrections.
+- Update Chart with correct image and chart version strings during builds.
 
 ### Added
 - Added new parameter for naming image customization results

--- a/kubernetes/cray-cfs-api/Chart.yaml
+++ b/kubernetes/cray-cfs-api/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-cfs-api
-version: 0.0.0
+version: 0.0.0-chart
 description: Kubernetes resources for config-framework-service
 keywords:
 - config-framework-service
@@ -39,11 +39,11 @@ dependencies:
 maintainers:
 - name: rbak-hpe
   email: ryan.bak@hpe.com
-appVersion: 0.0.0
+appVersion: 0.0.0-docker
 annotations:
   artifacthub.io/images: |
     - name: cray-cfs
-      image: artifactory.algol60.net/csm-docker/stable/cray-cfs:0.0.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-cfs:0.0.0-docker
     - name: redis
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis:5.0-alpine
   artifacthub.io/license: MIT

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -15,6 +15,14 @@
 #sourcefile: v2.txt
 #targetfile: 1/2/3.txt
 
+sourcefile: .version
 tag: 0.0.0
-targetfile: kubernetes/cray-cfs-api/Chart.yaml
 targetfile: api/openapi.yaml
+
+sourcefile: .chart_version
+tag: 0.0.0-chart
+targetfile: kubernetes/cray-cfs-api/Chart.yaml
+
+sourcefile: .docker_version
+tag: 0.0.0-docker
+targetfile: kubernetes/cray-cfs-api/Chart.yaml


### PR DESCRIPTION
## Summary and Scope

update_versions.conf was pulling the chart and Docker version strings from the .version file, rather than the .docker_version and .chart_version files. This meant that it always was using the a.b.c version string, omitting any extra fields. This PR modifies it so that the Chart is updated with the actual Docker and chart version strings. For stable artifacts on the master branch, this will be no change, but this will allow (for example) stable beta artifacts to retain the beta string in their versions.

## Testing

None beyond making sure the build works and the artifacts get the correct version strings.

## Risks and Mitigations

Extremely high risk. Incalculable.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
