### PR TITLE
CASMCMS-8089: Enable building of unstable artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Restricted parameters for configurations and status filtering
+- Enabled building of unstable artifacts
+- Updated header of update_versions.conf to reflect new tool options
 
 ### Fixed
 - Spelling corrections.
-- Update Chart with correct image and chart version strings during builds.
+- Updated Chart with correct image and chart version strings during builds.
 
 ### Added
 - Added new parameter for naming image customization results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Spelling corrections.
 - Updated Chart with correct image and chart version strings during builds.
+- Modified version string placeholder tag in openapi.yaml to avoid unintentional string replacement during builds.
 
 ### Added
 - Added new parameter for naming image customization results

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -25,7 +25,7 @@ openapi: "3.0.2"
 
 info:
   title: "Configuration Framework Service"
-  version: "0.0.0"
+  version: "0000.0000.0000"
   description: >
     The Configuration Framework Service (CFS) manages the launch of Ansible Execution Environments
     for image customization, node personalization, and node reconfiguration. CFS manages

--- a/kubernetes/cray-cfs-api/Chart.yaml
+++ b/kubernetes/cray-cfs-api/Chart.yaml
@@ -43,7 +43,7 @@ appVersion: 0.0.0-docker
 annotations:
   artifacthub.io/images: |
     - name: cray-cfs
-      image: artifactory.algol60.net/csm-docker/stable/cray-cfs:0.0.0-docker
+      image: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-cfs:0.0.0-docker
     - name: redis
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis:5.0-alpine
   artifacthub.io/license: MIT

--- a/kubernetes/cray-cfs-api/values.yaml
+++ b/kubernetes/cray-cfs-api/values.yaml
@@ -39,7 +39,7 @@ cray-service:
     cray-cfs-api:
       name: cray-cfs-api
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/cray-cfs
+        repository: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-cfs
         # tag defaults to chart appVersion
       volumeMounts:
         - name: ca-pubkey

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -19,7 +19,7 @@
 #override each other).
 
 sourcefile: .version
-tag: 0.0.0
+tag: 0000.0000.0000
 targetfile: api/openapi.yaml
 
 sourcefile: .chart_version

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -1,19 +1,22 @@
-#tag: version tag string to be replaced (optional -- if unspecified @VERSION@ is assumed)
-#sourcefile: file to read actual version from (optional -- if unspecified, .version is assumed)
-#targetfile: file in which to have version tags replaced
+#tag: Version tag string to be replaced (optional -- if unspecified @VERSION@ is assumed)
 #
-#Multiples of these lines are allowed. A given line is in effect until another line overrides it.
-#Example:
-#tag: @TAG1@
-#sourcefile: path/to/version1.txt
-#targetfile: my/file.py
-#targetfile: other/file.yaml
+#sourcefile: File to obtain the actual version from (optional -- if unspecified, .version is assumed)
+#            If this file is executable, it will be executed and the output will be used as the version string.
+#            Otherwise it will be read and its contents will be used as the version string, with any leading and
+#            trailing whitespace stripped. The version string is validated by the update_version.sh string to
+#            verify that they match the expected version formatting (essentially semver, with a minor exception
+#            -- see the script header for details).
+#sourcefile-novalidate: This is identical to the previous tag, except that the only validation that is
+#            done is to verify that the version string is not blank and does not contain strings which will
+#            disrupt the sed command used for the version tag replacement. Essentially, it cannot contain
+#            double quotes, forward slashes, or hash symbols. The file does still have leading and trailing
+#            whitespace stripped, however.
+#targetfile: file in which to have version tags replaced. When this line is reached, the replacement
+#            action is performed on this file.
 #
-#tag: @TAG2@
-#targetfile: a/b/c.txt
-#
-#sourcefile: v2.txt
-#targetfile: 1/2/3.txt
+#Multiples of any of these lines are allowed. A given line is in effect until another line overrides it.
+#For this purpose, the sourcefile and sourcefile-novalidate lines are considered the same (that is, they
+#override each other).
 
 sourcefile: .version
 tag: 0.0.0
@@ -26,3 +29,8 @@ targetfile: kubernetes/cray-cfs-api/Chart.yaml
 sourcefile: .docker_version
 tag: 0.0.0-docker
 targetfile: kubernetes/cray-cfs-api/Chart.yaml
+
+sourcefile-novalidate: .stable
+tag: S-T-A-B-L-E
+targetfile: kubernetes/cray-cfs-api/Chart.yaml
+targetfile: kubernetes/cray-cfs-api/values.yaml


### PR DESCRIPTION
## Summary and Scope

Currently the Chart.yaml and values.yaml files are hard-coded to point to stable directories on artifactory. The problem comes if an unstable artifact is built. That version of the docker image won't exist in that location out on artifactory, making the unstable chart unusable.

The fix is to adjust the path to stable or unstable based on the type of build being done. This was done in the BOS repo with this PR:
https://github.com/Cray-HPE/bos/pull/57

This PR does the same thing for the CFS repository.

I also noticed that there was an unintentional string replace happening in openapi.yaml during the builds:

```text
13:55:33  update_versions.sh: Replacing version tags (0.0.0) in api/openapi.yaml
13:55:33  update_versions.sh: # diff "api/openapi.yaml.after" "api/openapi.yaml"
13:55:33  28c28
13:55:33  <   version: "1.12.0"
13:55:33  ---
13:55:33  >   version: "0.0.0"
13:55:33  372c372
13:55:33  <                 example: ['nid1.12.01', 'nid1.12.02', 'nid1.12.03']
13:55:33  ---
13:55:33  >                 example: ['nid000001', 'nid000002', 'nid000003']
```

I changed the placeholder string to be 0000.0000.0000 to sidestep this issue.

## Testing

No testing beyond making sure that the builds produce the expected artifacts.

## Risks and Mitigations

Low risk. For stable artifacts, nothing is changed.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
