### PR TITLE
CASMCMS-8380: Linting of openapi spec file (no content changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Language linting of description text fields in openapi spec file
 
 ## [1.12.0] - 1/12/2023
 ### Changed

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-openapi: "3.0.2"
+openapi: "3.0.3"
 
 info:
   title: "Configuration Framework Service"
@@ -267,7 +267,7 @@ components:
       properties:
         hardwareSyncInterval:
           type: integer
-          description: How frequently the CFS hardware-sync-agent checks with the Hardware State Manager to update it's known hardware (in seconds)
+          description: How frequently the CFS hardware-sync-agent checks with the Hardware State Manager to update its known hardware (in seconds)
           example: 5
         batcherCheckInterval:
           type: integer
@@ -375,7 +375,7 @@ components:
         image_map:
           type: array
           description: |
-            Mapping of image ids to resultant image names.  This is only valid for 'image' inventory definition types.
+            Mapping of image IDs to resultant image names.  This is only valid for 'image' inventory definition types.
             Only images that are defined in 'groups' will result in a new image.
             If images in 'groups' are not specified here, CFS will generate a name for the resultant image.
           items:
@@ -663,7 +663,7 @@ components:
           readOnly: true
         description:
           type: string
-          description: A user defined description. This field is not used by CFS.
+          description: A user-defined description. This field is not used by CFS.
         lastUpdated:
           type: string
           description: The date/time when the state was last updated in RFC 3339 format.
@@ -770,7 +770,7 @@ components:
       properties:
         ids:
           type: string
-          description: A comma separated list of component ids
+          description: A comma-separated list of component IDs
         status:
           type: string
           description: All components with this status will be patched.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-openapi: "3.0.3"
+openapi: "3.0.2"
 
 info:
   title: "Configuration Framework Service"


### PR DESCRIPTION
## Summary and Scope

In a craycli PR, I did some linting of the CFS CLI text, and noticed some things to clean up in the API spec as well. No content changes -- just minor language cleanup in the API spec file.

## Issues and Related PRs

* [Cray CLI PR](https://github.com/Cray-HPE/craycli/pull/65)
* Resolves [CASMCMS-8380](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8380)

## Risks and Mitigations

Extremely low -- only minor changes made to description text fields in the API spec.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
