### PR TITLE
CASMCMS-8713: Bump PyYAML from 5.4.1 to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.12.3] - 7/18/2023
+### Dependencies
+- Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
 
 ## [1.12.2] - 4/10/2023
 ### Changed

--- a/constraints.txt
+++ b/constraints.txt
@@ -31,7 +31,7 @@ pycparser==2.19
 PyJWT==1.7.0
 pylint==2.3.1
 python-dateutil==2.6.0
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.22.0
 requests-oauthlib==1.0.0
 rsa==4.7


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/config-framework-service/pull/69 to allow support/1.12 branch to be buildable