### PR TITLE
CVE: CASMCMS-8718: Update version of cryptography dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.2] - 7/21/2023
+### Dependencies
+- Bump `cryptography` from 2.6.1 to 41.0.2 to fix [Improper Certificate Validation CVE](https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-5777683)
+
 ## [1.13.1] - 7/18/2023
 ### Dependencies
 - Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,7 @@ chardet==3.0.4
 click==6.7
 clickclick==1.2.2
 connexion==2.6.0
-cryptography==2.6.1
+cryptography==41.0.2
 Flask==1.0.4
 google-auth==1.6.1
 idna==2.8


### PR DESCRIPTION
## Summary and Scope

Pin the `cryptography` module to a version that fix this CVE:
https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-5777683

## Issues and Related PRs

* Resolves [CASMCMS-8718](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8718)
* [support/1.12 backport PR](https://github.com/Cray-HPE/config-framework-service/pull/73)
* Similar fixes have been and are being made in other repos:
  * `cfs-operator`: [CASMCMS-8715](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8715)
  * `ansible-execution-environment`: [CASMCMS-8717](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8717)

## Testing

On mug, I deployed cray-cfs and cray-cfs-operator using the CVE fixes contained in the following 3 PRs:
* https://github.com/Cray-HPE/ansible-execution-environment/pull/40
* https://github.com/Cray-HPE/config-framework-service/pull/72
* https://github.com/Cray-HPE/cfs-operator/pull/89

The deploys went fine. I ran the cmsdev CFS test, and it passed. I also cleared out the state for ncn-m001 so that it would re-run CFS on it. This also happened without any problems. I checked the pod logs for the CFS session, cfs-api, and cfs-operator, and didn't see any unusual warning messages that would indicate a compatibility problem.