### PR TITLE
CASMCMS-8772: Update jsonschema version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.14.1] - 8/24/2023
+### Fixed
+- Updated the jsonschema dependecny to address a bug in openapi-schema-validator
 
 ## [1.14.0] - 8/18/2023
 ### Added

--- a/constraints.txt
+++ b/constraints.txt
@@ -16,7 +16,7 @@ inflection==0.3.1
 isort==4.3.21
 itsdangerous==0.24
 Jinja2==2.10.3
-jsonschema==2.6.0
+jsonschema==3.0.0
 kafka-python==2.0.2
 kubernetes==11.0.0
 lazy-object-proxy==1.3.1


### PR DESCRIPTION
## Summary and Scope

Updated the jsonschema dependecny to address a bug in openapi-schema-validator

## Issues and Related PRs

* Resolves [CASMCMS-8772](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8772)
* Resolves [CASMTRIAGE-5948](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5948)

## Testing

### Tested on:

  * Mug

### Test description:

Deployed, verified migration happened, tested functionality after migration

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

