### PR TITLE
CASMTRIAGE-5974/5977

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.14.1] - 8/30/2023
+### Fixed
+- Fixed component id list filtering when used with paging
+
 ## [1.14.1] - 8/24/2023
 ### Fixed
 - Updated the jsonschema dependecny to address a bug in openapi-schema-validator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [1.14.1] - 8/30/2023
+## [1.14.2] - 8/30/2023
 ### Fixed
 - Fixed component id list filtering when used with paging
+- Fixed the options migrations when cfs-api is upgraded to v3 far ahead of other CFS services
 
 ## [1.14.1] - 8/24/2023
 ### Fixed

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -466,7 +466,7 @@ components:
             The git clone URL of a repo with additional inventory files.  All files in the repo will be copied into the hosts directory of CFS.
           example: https://api-gw-service-nmn.local/vcs/cray/inventory.git
           pattern: '^[^\s;]*$'
-          minLength: 1
+          minLength: 0
           maxLength: 120
         batcher_max_backoff:
           type: integer

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -160,21 +160,22 @@ def _component_filter(component_data, config_details, configs,
                       id_list, status_list, enabled, config_name, tag_list):
     _set_status(component_data, configs, config_details) # This sets the status both for filtering and for the response data
     if id_list or status_list or (enabled is not None) or config_name or tag_list:
-        return _matches_filter(component_data, status_list, enabled, config_name, tag_list)
+        return _matches_filter(component_data, id_list, status_list, enabled, config_name, tag_list)
     else:
         # No filter is being used so all components are valid
         return True
 
 
-def _matches_filter(data, status, enabled, config_name, tags):
-    data_status = data.get('configuration_status', '')
-    if status and not any([data_status == s for s in status]):
+def _matches_filter(data, id_list, status_list, enabled, config_name, tag_list):
+    if id_list and not data.get("id") in id_list:
         return False
-    if enabled is not None and data.get('enabled', None) != enabled:
+    if status_list and not data.get('configuration_status') in status_list:
         return False
-    if config_name and data.get('desired_config', '') != config_name:
+    if enabled is not None and data.get('enabled') != enabled:
         return False
-    if tags and any([data.get('tags', {}).get(k) != v for k, v in tags]):
+    if config_name and data.get('desired_config') != config_name:
+        return False
+    if tag_list and any([data.get('tags', {}).get(k) != v for k, v in tag_list]):
         return False
     return True
 

--- a/src/server/cray/cfs/api/controllers/options.py
+++ b/src/server/cray/cfs/api/controllers/options.py
@@ -46,6 +46,7 @@ DEFAULTS = {
 
 
 def _init():
+    cleanup_old_options()
     # Start options refresh
     options_refresh = threading.Thread(target=periodically_refresh_options, args=())
     options_refresh.start()


### PR DESCRIPTION
## Summary and Scope

Fixes two CFS bugs
- Fixes component list when filtering by id
- Fixes repeat upgrade migrations when other CFS services repopulated the old options data format during the initial migration. 

## Issues and Related PRs

* Resolves CASMTRIAGE-5974
* Resolves CASMTRIAGE-5977

## Testing

### Tested on:

  * Mug

### Test description:

Tested migration that was previously failing, and tested id filtering for both the v2 and v3 apis.


## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

