### PR TITLE
CASMCMS-8789: Add ims_job field to session status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added an ims_job field for session status
+
 ## [1.14.2] - 8/30/2023
 ### Fixed
 - Fixed component id list filtering when used with paging

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -687,7 +687,10 @@ components:
         job:
           description: The name of the configuration execution environment associated with this session.
           example: cray-cfs-job-session-20190728032600
-          readOnly: true
+          type: string
+        ims_job:
+          description: The name os the IMS job associated with the session when running against an image.
+          example: 5037edd8-e9c5-437d-b54b-db4a8ad2cb15
           type: string
         completion_time:
           description: The date/time when the session completed execution in RFC 3339 format.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -467,7 +467,7 @@ components:
           example: https://api-gw-service-nmn.local/vcs/cray/inventory.git
           pattern: '^[^\s;]*$'
           minLength: 0
-          maxLength: 120
+          maxLength: 240
         batcher_max_backoff:
           type: integer
           description: >
@@ -905,6 +905,7 @@ components:
             can be used to specify nodes or groups.
           example: host1
           pattern: '^[^\s;]*$'
+          default: ""
         ansible_config:
           type: string
           description: >-
@@ -930,6 +931,7 @@ components:
             "--skip-tags", "--start-at-task", and "--tags". WARNING: Parameters passed to Ansible in
             this way should be used with caution.  State will not be recorded for components when
             using these flags to avoid incorrect reporting of partial playbook runs.
+          default: ""
         target:
           $ref: '#/components/schemas/SessionTargetSection'
         tags:


### PR DESCRIPTION
## Summary and Scope

Adds an ims_job field to session status to allow tracking and cleanup of the IMS jobs created for image customization.

## Issues and Related PRs

* Resolves CASMCMS-8789

## Testing

### Tested on:

  * Mug
 
### Test description:

Verified the ims_job field exists and was being written to by the cfs-operator

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

