### PR TITLE
CASMTRIAGE-6032: Fix component layer status handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added an ims_job field for session status
 
+### Fixed
+- Fixed component status handling for failed and incomplete layers
+
 ## [1.14.2] - 8/30/2023
 ### Fixed
 - Fixed component id list filtering when used with paging

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -607,16 +607,16 @@ def _get_layer_status(desired_state, current_state_layers, max_retries):
         return STATUS_UNCONFIGURED
 
     for current_state in current_state_layers:
-        current_commit = current_state.get('commit', '')
+        current_status = current_state.get('status', '')
         if all([desired_clone_url == current_state.get('clone_url', ''),
                 desired_playbook == current_state.get('playbook', ''),
-                desired_commit in current_commit]):
-            if '_failed' in current_commit:
+                desired_commit == current_state.get('commit', '')]):
+            if current_status == 'failed':
                 if max_retries:
                     return STATUS_FAILED
                 else:
                     return STATUS_PENDING
-            if '_incomplete' in current_commit:
+            if current_status == 'incomplete' :
                 # Set for successful nodes when any_errors_fatal causes a playbook to exit early.
                 return STATUS_PENDING
             return STATUS_CONFIGURED


### PR DESCRIPTION
## Summary and Scope

Fixes a bug introduced by the v3 code changes that causes failed and incomplete layers to be incorrectly marked as configured when aggregating status.

## Issues and Related PRs

* Resolves CASMTRIAGE-6032

## Testing

### Tested on:

  * Mug

### Test description:

Setup a component with the problem state and validated the the status was correctly calculated after updating the api.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

