### PR TITLE
CASMTRIAGE-6041: Fix v2 sessions with long configuration names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+## Fixed
+- Fixed v2 session creation with configuration names exceeding the v3 limit.
+
 ## [1.15.0] - 9/23/2023
 ### Added
 - Added an ims_job field for session status


### PR DESCRIPTION
## Summary and Scope

Fixes a bug introduced by the v3 code that was making it impossible to create sessions using the v2 endpoint with configuration names longer than the limit imposed on that field in the v3 api.

## Issues and Related PRs

* Resolves CASMTRIAGE-6041

## Testing

### Tested on:

  * Mug

### Test description:

Tested commands that were previously failing and compared the behaviors of the v2 and v3 apis.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

