### PR TITLE
CASMCMS-8790: Add sources to the CFS api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added sources to support cloning from external repos
+- Added a drop_branches option when updating configurations
+
 ## [1.16.1] - 10/11/2023
 ## Fixed
 - Fixed v2 session creation using the wrong configuration name.

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY src/server/cray/cfs/api/__main__.py \
      src/server/cray/cfs/api/dbutils.py \
      src/server/cray/cfs/api/kafka_utils.py \
      src/server/cray/cfs/api/k8s_utils.py \
+     src/server/cray/cfs/api/vault_utils.py \
      src/server/cray/cfs/api/migrations.py \
      lib/server/cray/cfs/api/
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,10 @@ info:
     /components - Add, update, retrieve, or delete component information.
 
 
-    /configurations - Add, update, retrieve or delete desired configuration states. (v2 api only)
+    /configurations - Add, update, retrieve or delete desired configuration states.
+
+
+    /sources - Add, update, retrieve, or delete playbook source information. (v3 api only)
 
     ## Workflows
 
@@ -187,6 +190,20 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V3ConfigurationData'
+    V3SourceCreateRequest:
+      description: A source
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V3SourceCreateData'
+    V3SourceUpdateRequest:
+      description: A source
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V3SourceUpdateData'
   responses:
     # Success
     Version:
@@ -297,6 +314,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V3ConfigurationDataCollection'
+    V3SourceData:
+      description: A single source
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V3SourceData'
+    V3SourceDataCollection:
+      description: A collection of sources
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V3SourceDataCollection'
     ResourceDeleted:
       description: The resource was deleted.
     # Errors
@@ -314,6 +343,12 @@ components:
             $ref: '#/components/schemas/ProblemDetails'
     ConflictingSessionName:
       description: A session with the same name already exists.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    ConflictingSourceName:
+      description: A source with the same name already exists
       content:
         application/problem+json:
           schema:
@@ -464,10 +499,19 @@ components:
           type: string
           description: >
             The git clone URL of a repo with additional inventory files.  All files in the repo will be copied into the hosts directory of CFS.
+            This is mutually exclusive with the additional_inventory_source option and only one can be set.
           example: https://api-gw-service-nmn.local/vcs/cray/inventory.git
           pattern: '^[^\s;]*$'
           minLength: 0
           maxLength: 240
+        additional_inventory_source:
+          type: string
+          description: >
+            A CFS source with additional inventory files.  All files in the repo will be copied into the hosts directory of CFS.
+            This is mutually exclusive with the additional_source_url option and only one can be set.
+          example: example-source
+          minLength: 0
+          maxLength: 60
         batcher_max_backoff:
           type: integer
           description: >
@@ -1019,6 +1063,9 @@ components:
           description: The clone URL of the configuration content repository.
           example: https://vcs.domain/vcs/org/inventory.git
           pattern: '^[^\s;]*$'
+        source:
+          type: string
+          description: A CFS source with directions to the configuration content repository
         commit:
           type: string
           description: The commit hash of the configuration repository when the state is set.
@@ -1089,6 +1136,9 @@ components:
           description: The clone URL of the configuration content repository.
           example: https://api-gw-service-nmn.local/vcs/cray/config-management.git
           pattern: '^[^\s;]*$'
+        source:
+          type: string
+          description: A CFS source with directions to the configuration content repository
         playbook:
           type: string
           description: The Ansible playbook to run.
@@ -1104,7 +1154,7 @@ components:
             The configuration branch to use.  This will automatically set commit to master on the branch
             when the configuration is added.
           pattern: '^[^\s;]*$'
-      required: [clone_url, playbook]
+      required: [playbook]
       additionalProperties: false
     V2Configuration:
       description: A collection of ConfigurationLayers.
@@ -1420,6 +1470,149 @@ components:
         filters:
           $ref: '#/components/schemas/V3ComponentsFilter'
       required: [patch, filters]
+    ## SOURCES ENDPOINT ##
+    V3SourceCredentials:
+      description: Information for retrieving the git credentials
+      type: object
+      properties:
+        authentication_method:
+          type: string
+          description: The git authentication method used.
+          enum:
+            - password
+#            - token
+#            - key
+        secret_name:
+          type: string
+          description: The name of the credentials vault secret.
+          readOnly: true
+        username:
+          type: string
+          description: The username for authenticating to git
+          writeOnly: true
+        password:
+          type: string
+          description: The password for authenticating to git
+          writeOnly: true
+      additionalProperties: false
+    V3SourceCert:
+      description: CA certificate info for retrieving the git credentials
+      type: object
+      properties:
+        configmap_name:
+          type: string
+          description: The name of the configmap containing a necessary CA cert.
+          minLength: 1
+        configmap_namespace:
+          type: string
+          description: The namespace of the CA cert configmap in kubernetes.
+      additionalProperties: false
+      required:
+        - configmap_name
+    V3SourceData:
+      description: Information for retrieving git content from a source.
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the configuration.  This field is optional and will default to the clone_url if not specified.
+          example: sample-config
+        description:
+          type: string
+          description: A user-defined description. This field is not used by CFS.
+        last_updated:
+          type: string
+          description: The date/time when the state was last updated in RFC 3339 format.
+          example: '2019-07-28T03:26:00Z'
+          format: date-time
+          readOnly: true
+        clone_url:
+          type: string
+          description: The url to access the git content
+        credentials:
+          $ref: '#/components/schemas/V3SourceCredentials'
+          description: Information on a secret containing the username and password for accessing the git content
+        ca_cert:
+          $ref: '#/components/schemas/V3SourceCert'
+          description: Information on a configmap containing a CA certificate for authenticating to git
+          nullable: true
+      additionalProperties: false
+    V3SourceDataCollection:
+      description: A collection of source data.
+      type: object
+      properties:
+        components:
+          type: array
+          items:
+            $ref: '#/components/schemas/V3SourceData'
+        next:
+          $ref: '#/components/schemas/V3NextData'
+    V3SourceCreateCredentials:
+      description: Information for retrieving the git credentials
+      type: object
+      properties:
+        authentication_method:
+          type: string
+          description: The git authentication method used.
+          enum:
+            - password
+          default: password
+        username:
+          type: string
+          description: The username for authenticating to git
+          writeOnly: true
+        password:
+          type: string
+          description: The password for authenticating to git
+          writeOnly: true
+      additionalProperties: false
+      required:
+        - username
+        - password
+    V3SourceCreateData:
+      description: Information for retrieving git content from a source.
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the configuration.  This field is optional and will default to the clone_url if not specified.
+          example: sample-config
+        description:
+          type: string
+          description: A user-defined description. This field is not used by CFS.
+        clone_url:
+          type: string
+          description: The url to access the git content
+        credentials:
+          $ref: '#/components/schemas/V3SourceCreateCredentials'
+          description: Information on a secret containing the username and password for accessing the git content
+        ca_cert:
+          $ref: '#/components/schemas/V3SourceCert'
+          description: Information on a configmap containing a CA certificate for authenticating to git
+          nullable: true
+      additionalProperties: false
+      required:
+        - clone_url
+        - credentials
+    V3SourceUpdateData:
+      description: Information for retrieving git content from a source.
+      type: object
+      properties:
+        description:
+          type: string
+          description: A user-defined description. This field is not used by CFS.
+        clone_url:
+          type: string
+          description: The url to access the git content
+        credentials:
+          $ref: '#/components/schemas/V3SourceCredentials'
+          description: Information on a secret containing the username and password for accessing the git content
+        ca_cert:
+          $ref: '#/components/schemas/V3SourceCert'
+          description: Information on a configmap containing a CA certificate for authenticating to git
+          nullable: true
+      additionalProperties: false
+    ## OTHER ##
     ProblemDetails:
       description: An error response for RFC 7807 problem details.
       type: object
@@ -2505,6 +2698,14 @@ paths:
       operationId: put_configuration_v3
       requestBody:
         $ref: '#/components/requestBodies/V3ConfigurationUpdateRequest'
+      parameters:
+        - name: drop_branches
+          schema:
+            type: boolean
+            default: false
+          in: query
+          description: >-
+            Don't store the branches after converting each branch to a commit.
       responses:
         200:
           $ref: '#/components/responses/V3ConfigurationData'
@@ -2549,3 +2750,112 @@ paths:
           type: string
           minLength: 1
           maxLength: 60
+  /v3/sources:
+    get:
+      summary: Retrieve a collection of sources
+      tags:
+        - sources
+        - v3
+      x-openapi-router-controller: cray.cfs.api.controllers.sources
+      description: >-
+        Retrieve the full collection of sources in the form of a
+        SourceArray.
+      operationId: get_sources_v3
+      parameters:
+        - name: limit
+          schema:
+            type: integer
+            minimum: 1
+          in: query
+          description: >-
+            When set, CFS will only return a number of sources up to this limit.  Combined with after_id, this
+            enables paging across results
+        - name: after_id
+          schema:
+            type: string
+          in: query
+          description: >-
+            When set, CFS will only return the configurations after the source specified.  Combined with limit, this
+            enables paging across results.
+        - name: in_use
+          schema:
+            type: boolean
+          in: query
+          description: >-
+            Query for only sources that are currently referenced by configurations.
+      responses:
+        200:
+          $ref: '#/components/responses/V3SourceDataCollection'
+        400:
+          $ref: '#/components/responses/BadRequest'
+    post:
+      summary: Add a single source
+      tags:
+        - sources
+        - v3
+      x-openapi-router-controller: cray.cfs.api.controllers.sources
+      description: Add a source to CFS
+      operationId: post_source_v3
+      requestBody:
+        $ref: '#/components/requestBodies/V3SourceCreateRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/V3SourceData'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        409:
+          $ref: '#/components/responses/ConflictingSourceName'
+  /v3/sources/{source_id}:
+    get:
+      summary: Retrieve a single source
+      tags:
+        - sources
+        - v3
+      x-openapi-router-controller: cray.cfs.api.controllers.sources
+      description: Retrieve the given source
+      operationId: get_source_v3
+      responses:
+        200:
+          $ref: '#/components/responses/V3SourceData'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+    patch:
+      summary: Update the commits for a source
+      tags:
+        - sources
+        - v3
+      x-openapi-router-controller: cray.cfs.api.controllers.sources
+      description: Updates a CFS source
+      operationId: patch_source_v3
+      requestBody:
+        $ref: '#/components/requestBodies/V3SourceUpdateRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/V3SourceData'
+        400:
+          $ref: '#/components/responses/BadRequest'
+    delete:
+      tags:
+        - sources
+        - v3
+      summary: Delete a single source
+      x-openapi-router-controller: cray.cfs.api.controllers.sources
+      description:  >-
+        Delete the given source. This will fail in any components are using
+        the specified source.
+      operationId: delete_source_v3
+      responses:
+        204:
+          $ref: '#/components/responses/ResourceDeleted'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/ResourceNotFound'
+    parameters:
+      - name: source_id
+        in: path
+        description: Name of the target source
+        required: true
+        schema:
+          type: string
+          minLength: 1

--- a/kubernetes/cray-cfs-api/values.yaml
+++ b/kubernetes/cray-cfs-api/values.yaml
@@ -58,6 +58,8 @@ cray-service:
             secretKeyRef:
               name: vcs-user-credentials
               key: vcs_password
+        - name: VAULT_ADDR
+          value: http://cray-vault.vault:8200
       ports:
         - name: http
           containerPort: 9000

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ requests
 redis
 kafka-python
 ujson
+hvac
 
 # The purpose of this file is to contain python runtime requirements
 # for controller code, e.g., code authored by developers, as opposed to

--- a/src/server/cray/cfs/api/controllers/options.py
+++ b/src/server/cray/cfs/api/controllers/options.py
@@ -195,6 +195,10 @@ class Options:
     def include_ara_links(self):
         return self.get_option('include_ara_links', bool, True)
 
+    @property
+    def additional_inventory_source(self):
+        return self.get_option('additional_inventory_source', str, default="")
+
 
 def update_log_level(new_level_str):
     new_level = logging.getLevelName(new_level_str.upper())

--- a/src/server/cray/cfs/api/controllers/sources.py
+++ b/src/server/cray/cfs/api/controllers/sources.py
@@ -1,0 +1,241 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+import connexion
+from datetime import datetime
+from functools import partial
+import logging
+import uuid
+import urllib.parse
+
+from cray.cfs.api import dbutils
+from cray.cfs.api.controllers import configurations
+from cray.cfs.api.controllers import options
+
+from cray.cfs.api.vault_utils import put_secret as put_vault_secret
+from cray.cfs.api.vault_utils import delete_secret as delete_vault_secret
+
+LOGGER = logging.getLogger('cray.cfs.api.controllers.sources')
+DB = dbutils.get_wrapper(db='sources')
+TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+
+@dbutils.redis_error_handler
+@options.defaults(limit="default_page_size")
+def get_sources_v3(in_use=None, limit=1, after_id=""):
+    """Used by the GET /sources API operation"""
+    LOGGER.debug("GET /sources invoked get_sources_v3")
+    called_parameters = locals()
+    sources_data, next_page_exists = _get_sources_data(in_use=in_use, limit=limit, after_id=after_id)
+    response = {"sources": sources_data, "next": None}
+    if next_page_exists:
+        next_data = called_parameters
+        next_data["after_id"] = sources_data[-1]["name"]
+        response["next"] = next_data
+    return response, 200
+
+
+@options.defaults(limit="default_page_size")
+def _get_sources_data(in_use=None, limit=1, after_id=""):
+    source_filter = partial(_source_filter, in_use=in_use, in_use_list=_get_in_use_list())
+    source_data_page, next_page_exists = DB.get_all(limit=limit, after_id=after_id, data_filter=source_filter)
+    return source_data_page, next_page_exists
+
+
+def _source_filter(source_data, in_use, in_use_list):
+    if in_use is not None:
+        return _matches_filter(source_data, in_use, in_use_list)
+    else:
+        # No filter is being used so all components are valid
+        return True
+
+
+def _matches_filter(source_data, in_use, in_use_list):
+    if in_use is not None and (source_data["name"] in in_use_list) != in_use:
+            return False
+    return True
+
+
+def _get_in_use_list():
+    in_use_list = set()
+    source = options.Options().additional_inventory_source
+    if source:
+        in_use_list.add(source)
+    for configuration in _iter_configurations_data():
+        source = configuration.get("additional_inventory_source", "")
+        if source and type(source) == str:
+            in_use_list.add(source)
+        for layer in configuration.get("layers"):
+            source = layer.get("source", "")
+            if source:
+                in_use_list.add(source)
+    return list(in_use_list)
+
+
+def _iter_configurations_data():
+    next_parameters = {}
+    while True:
+        data, _ = configurations.get_configurations_v3(**next_parameters)
+        for component in data["configurations"]:
+            yield component
+        next_parameters = data["next"]
+        if not next_parameters:
+            break
+
+
+@dbutils.redis_error_handler
+def get_source_v3(source_id):
+    """Used by the GET /sources/{source_id} API operation"""
+    LOGGER.debug(f"GET /sources/{source_id} invoked get_source_v3")
+    source_id = urllib.parse.unquote(source_id)
+    if source_id not in DB:
+        return connexion.problem(
+            status=404, title="Source not found",
+            detail="Source {} could not be found".format(source_id))
+    return DB.get(source_id), 200
+
+
+@dbutils.redis_error_handler
+def post_source_v3():
+    """Used by the POST /sources/ API operation"""
+    LOGGER.debug("POST /sources/ invoked post_source_v3")
+    try:
+        data = connexion.request.get_json()
+    except Exception as err:
+        return connexion.problem(
+            status=400, title="Error parsing the data provided.",
+            detail=str(err))
+
+    error = _validate_source(data)
+    if error:
+        return error
+    data = _set_auto_fields(data)
+
+    if not data.get("name"):
+        data["name"] = data["clone_url"]
+
+    if data["name"] in DB:
+        return connexion.problem(
+            detail="A source with the name {} already exists".format(data["name"]),
+            status=409,
+            title="Conflicting source name"
+        )
+
+    data = _update_credentials_secret(data)
+    return DB.put(data.get("name"), data), 200
+
+
+@dbutils.redis_error_handler
+def patch_source_v3(source_id):
+    """Used by the PATCH /sources/{source_id} API operation"""
+    LOGGER.debug(f"PATCH /sources/{source_id} invoked patch_source_v3")
+    source_id = urllib.parse.unquote(source_id)
+    if source_id not in DB:
+        return connexion.problem(
+            status=404, title="Source not found.",
+            detail="Source {} could not be found".format(source_id))
+    try:
+        data = connexion.request.get_json()
+    except Exception as err:
+        return connexion.problem(
+            status=400, title="Error parsing the data provided.",
+            detail=str(err))
+
+    error = _validate_source(data)
+    if error:
+        return error
+    data = _set_auto_fields(data)
+
+    response_data = DB.patch(source_id, data, update_handler=_update_credentials_secret)
+    return response_data, 200
+
+
+def _validate_source(source):
+    source_credentials = source.get("credentials")
+    if source_credentials:
+        source_credentials_type = source_credentials.get("authentication_method")
+        if not source_credentials_type or source_credentials_type == "password":
+            if not (source_credentials.get("username") and source_credentials.get("password")):
+                return connexion.problem(
+                    status=400, title="Invalid credentials",
+                    detail="Both username and password must be provided for password authentication credentials")
+    return None
+
+
+def _update_credentials_secret(source):
+    source_credentials = source.get("credentials")
+    if not source_credentials:
+        return source
+    secret_name = source_credentials.get("secret_name")
+    if not secret_name:
+        secret_name = f"cfs-source-credentials-{uuid.uuid4()}"
+        source["credentials"]["secret_name"] = secret_name
+    authentication_method = source_credentials.get("authentication_method")
+    if authentication_method == "password" and source_credentials.get("username") and source_credentials.get("password"):
+        secret_data = {"username": source_credentials["username"],
+                       "password": source_credentials["password"]}
+        put_vault_secret(secret_name, secret_data)
+    source = _clean_credentials_data(source)
+    return source
+
+
+def _clean_credentials_data(data):
+    credentials = data.get("credentials")
+    if not credentials:
+        return data
+    clean_credentials = {}
+    for field in ["authentication_method", "secret_name"]:
+        clean_credentials[field] = credentials[field]
+    data["credentials"] = clean_credentials
+    return data
+
+
+@dbutils.redis_error_handler
+def delete_source_v3(source_id):
+    """Used by the DELETE /sources/{source_id} API operation"""
+    LOGGER.debug(f"DELETE /sources/{source_id} invoked delete_source_v3")
+    source_id = urllib.parse.unquote(source_id)
+    if source_id not in DB:
+        return connexion.problem(
+            status=404, title="Source not found",
+            detail="Source {} could not be found".format(source_id))
+    if source_id in _get_in_use_list():
+        return connexion.problem(
+            status=400, title="Source is in use.",
+            detail="Source {} is referenced by some configurations".format(source_id))
+    source = DB.get(source_id)
+    source_credentials = source.get("credentials", {})
+    if source_credentials and source_credentials.get("secret_name"):
+        delete_vault_secret(source_credentials["secret_name"])
+    return DB.delete(source_id), 204
+
+
+def _set_auto_fields(data):
+    data = _set_last_updated(data)
+    return data
+
+
+def _set_last_updated(data):
+    data['last_updated'] = datetime.now().strftime(TIME_FORMAT)
+    return data

--- a/src/server/cray/cfs/api/dbutils.py
+++ b/src/server/cray/cfs/api/dbutils.py
@@ -32,7 +32,7 @@ from kubernetes.config.config_exception import ConfigException
 from cray.cfs.api.models.base_model_ import Model as BaseModel
 
 LOGGER = logging.getLogger(__name__)
-DATABASES = ["options", "sessions", "components", "configurations"]  # Index is the db id.
+DATABASES = ["options", "sessions", "components", "configurations", "sources"]  # Index is the db id.
 
 try:
     config.load_incluster_config()


### PR DESCRIPTION
## Summary and Scope

Adds "sources" to the CFS API.  This allows users to specify repos, as well as their credentials and ca certs, so that CFS can access Ansible content outside the standard VCS.

Also includes a new option to drop the branch field from configurations after converting it to a commit

## Issues and Related PRs

* Resolves CASMCMS-8790
* Resolves CASMCMS-8794

## Testing

### Tested on:

  * Mug

### Test description:

- Tested updating, patching and deleting various sources.
- Tested adding configurations with branches, with and without sources (so the branch was converted in the API)
- Tested CFS sessions using configurations with and without sources.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

