### PR TITLE
CASMTRIAGE-6158: Fix v2 session creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.1] - 10/11/2023
+## Fixed
+- Fixed v2 session creation using the wrong configuration name.
+
 ## [1.16.0] - 9/29/2023
 ## Fixed
 - Fixed v2 session creation with configuration names exceeding the v3 limit.

--- a/src/server/cray/cfs/api/controllers/sessions.py
+++ b/src/server/cray/cfs/api/controllers/sessions.py
@@ -113,7 +113,7 @@ def create_session_v2():  # noqa: E501
     session = _create_session(session_create)
     session_data = session.to_dict()
     # This is a workaround for the addition of the configuration name max length in v3
-    session_data['configuration_name'] = v2_session_configuration
+    session_data['configuration']['name'] = v2_session_configuration
     # end workaround
     session_data['status']['session']['start_time'] = datetime.datetime.now().isoformat(timespec='seconds')
     _kafka.produce(event_type='CREATE', data=session_data)


### PR DESCRIPTION
## Summary and Scope

Fixes an issue introduced by the workaround for long configuration names, that was causing sessions to use the wrong configuration when creating v2 sessions.

## Issues and Related PRs

* Resolves CASMTRIAGE-6158

## Testing

### Tested on:

  * beau

### Test description:

Successfully created a v2 session with the correct configuration using a command that had previously been failing.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

