### PR TITLE
CASMTRIAGE-6403: Fix branch conversion for additional inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.1] - 12/06/2023
+## Fixed
+- Fixed branch conversion for additional inventory in the configuration
+
 ## [1.17.0] - 10/18/2023
 ### Added
 - Added sources to support cloning from external repos

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -301,7 +301,7 @@ def delete_configuration_v3(configuration_id):
 
 def _iter_layers(config_data, include_additional_inventory=True):
     if include_additional_inventory and config_data.get("additional_inventory"):
-        for layer in (config_data.get('layers') + config_data.get('additional_inventory')):
+        for layer in (config_data.get('layers') + [config_data.get('additional_inventory')]):
             yield layer
     else:
         for layer in config_data.get('layers'):


### PR DESCRIPTION
## Summary and Scope

Fixes a bug when trying to covert the branch to commit when using the additional_inventory field in a a configuration.

## Issues and Related PRs

* Resolves CASMTRIAGE-6403

## Testing

### Tested on:

  * Mug

### Test description:

Validated the test case that had been failing

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

