### PR TITLE
CASMCMS-8888: Correct accidental use of Kubernetes Python client insead of DB client in patch_all method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - v3 source creation now returns 201 on success, per convention
     for indicating successful creation of a new resource
 - Corrected minor mistake in a code comment
+- Fix bug in patch_all method in dbutils (use DB client, not Kubernetes Python module)
 
 ## [1.17.2] - 12/08/2023
 ## Fixed

--- a/src/server/cray/cfs/api/dbutils.py
+++ b/src/server/cray/cfs/api/dbutils.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -163,7 +163,7 @@ class DBWrapper():
         """Patch multiple resources in the database."""
         # Redis SCAN operations can produce duplicate results.  Using a set fixes this.
         keys = set()
-        for key in client.scan_iter():
+        for key in self.client.scan_iter():
             keys.add(key)
         # Sorting the keys guarantees a consistent order when paging
         sorted_keys = sorted(list(keys))


### PR DESCRIPTION
## Summary and Scope

The `patch_all` method in `dbutils` accidentally omitted a `self.` when trying to call a database function, so it accidentally was trying to use the Kubernetes Python module. This did not work well, and breaks one of the v3 components patching paths.

I am making this PR against my other development branch because I want to test the fixes together.

## Issues and Related PRs

* Resolves [CASMCMS-8888](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8888)

## Testing

The fix looks good. The operation does still fail, though, but now it is for the reason I expected -- the one I am pursuing with [CASMCMS-8887](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8887)

## Risks and Mitigations

Low risk -- the function is broken as is.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
