### PR TITLE
CASMCMS-8887: Decode IDs from bytes to UTF-8 strings in patch_all/delete_all methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     for indicating successful creation of a new resource
 - Corrected minor mistake in a code comment
 - Fix bug in patch_all method in dbutils (use DB client, not Kubernetes Python module)
+- Convert bytes to strings in patch_all and delete_all methods in dbutils, so
+  they can be JSON serialized
 
 ## [1.17.2] - 12/08/2023
 ## Fixed

--- a/src/server/cray/cfs/api/dbutils.py
+++ b/src/server/cray/cfs/api/dbutils.py
@@ -179,7 +179,8 @@ class DBWrapper():
                     data = update_handler(data)
                 data_str = json.dumps(data)
                 self.client.set(key, data_str)
-                patched_id_list.append(key)
+                # Decode the key into a UTF-8 string, so the list will be JSON serializable
+                patched_id_list.append(key.decode('utf-8'))
         return patched_id_list
 
     def _update(self, data, new_data):
@@ -212,7 +213,8 @@ class DBWrapper():
                 self.client.delete(key)
                 if deletion_handler:
                     deletion_handler(data)
-                deleted_id_list.append(key)
+                # Decode the key into a UTF-8 string, so the list will be JSON serializable
+                deleted_id_list.append(key.decode('utf-8'))
         return deleted_id_list
 
     def info(self):


### PR DESCRIPTION
## Summary and Scope

The v3 multi-session delete and v3 multi-component patch endpoints can succeed but return 500 status codes because they try to return a list of bytes, and those are not JSON serializable. This PR decodes the bytes into UTF-8 strings, preventing this problem.

This PR is deliberately against another dev branch, because I want to test them together.

## Issues and Related PRs

* Resolves [CASMCMS-8887](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8887)
* Related to [CASMCMS-8888](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8888)

## Testing

With this fix in place, both the patch multi-updates and the session multi-deletes work as they should.

## Risks and Mitigations

Low risk -- without this, these return calls only work when the lists are empty.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
