### PR TITLE
CASMCMS-8920: Fix ARA link for sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.1] - 02/26/2024
+### Fixed
+- Fixed ARA link returned with session data
+
 ## [1.18.0] - 01/12/2024
 ### Fixed
 - Changed API behavior to match spec

--- a/src/server/cray/cfs/api/controllers/sessions.py
+++ b/src/server/cray/cfs/api/controllers/sessions.py
@@ -741,7 +741,7 @@ def _age_to_timestamp(age):
 
 def _set_link(data):
     if options.Options().include_ara_links:
-        data["logs"] = f"{get_ara_ui_url()}/hosts?label={data['name']}"
+        data["logs"] = f"{get_ara_ui_url()}/?label={data['name']}"
     return data
 
 


### PR DESCRIPTION
## Summary and Scope

Fixes the link for ARA returned with session data

## Issues and Related PRs

* Resolves CASMCMS-8920

## Testing

### Tested on:

  * Mug

### Test description:

Verified the API output and that it linked to the expected page.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable