### PR TITLE
CASMTRIAGE-6865: Fix bug in patch_v2_components_dict that causes only a single component to be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix bug in `patch_v2_components_dict` that causes it to only patch a single component.
 
 ## [1.12.5] - 4/4/2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.12.6] - 4/5/2024
 ### Fixed
 - Fix bug in `patch_v2_components_dict` that causes it to only patch a single component.
 

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -218,7 +218,7 @@ def patch_v2_components_dict(data):
         for component_id in id_list:
             component_data = DB.get(component_id)
             if component_data:
-                components.append(component_data)
+                components.append((component_id, component_data))
     else:
         # TODO: On large scale systems, this response may be too large
         # and require paging to be implemented
@@ -229,8 +229,8 @@ def patch_v2_components_dict(data):
     if "id" in patch:
         del patch["id"]
     patch = _set_auto_fields(patch)
-    for component in components:
-        if _matches_filter(component, status_list, filters.get("enabled", None),
+    for component_id, component_data in components:
+        if _matches_filter(component_data, status_list, filters.get("enabled", None),
                            filters.get("configName", None), tag_list):
             response.append(DB.patch(component_id, patch, _update_handler))
     return response, 200


### PR DESCRIPTION
This fixes a very simple bug in the `patch_v2_components_dict` function. The loop at its end is supposed to be updating each component that has been identified. However, it uses the wrong variable for the component ID, causing it to just update the same component over and over. We can see this because if we call CFS to patch 100 components using this function, we get back a response that shows it patched a single component 100 times.

Looking at the companion function `patch_v2_components_list`, I assume there was just some confusion that led to this bug. I made a fix that makes the two functions more closely parallel each other, since I think there subtle differences are what led to this bug in the first place. Hopefully by making them follow each other more closely, it will make future bugs less likely.

I am going to test this on wasp shortly, but I'm putting it up for review at the same time, because UKMet very much wants this fix, and I think it's pretty straightforward.