### PR TITLE
CASMCMS-8962: Properly handle response from DB.get_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix bug in `patch_v2_components_dict` to properly handle response from `DB.get_all()`
 
 ## [1.12.6] - 4/5/2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.12.7] - 4/5/2024
 ### Fixed
 - Fix bug in `patch_v2_components_dict` to properly handle response from `DB.get_all()`
 

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -222,7 +222,7 @@ def patch_v2_components_dict(data):
     else:
         # TODO: On large scale systems, this response may be too large
         # and require paging to be implemented
-        components = DB.get_all()
+        components = [ (component_data["id"], component_data) for component_data in DB.get_all() ]
 
     response = []
     patch = data.get("patch", {})


### PR DESCRIPTION
This addresses Jason's astute review comment: https://github.com/Cray-HPE/config-framework-service/pull/116#discussion_r1554289984

Note that this will require backports to the newer versions, because this problem existed in Ryan's fix to this bug as well:
https://github.com/Cray-HPE/config-framework-service/pull/122
https://github.com/Cray-HPE/config-framework-service/pull/123