### PR TITLE
CASMCMS-8962: Properly handle response from DB.get_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix bug in `patch_v2_components_dict` to properly handle response from `DB.get_all()`
 
 ## [1.19.2] - 04/04/2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.19.3] - 04/05/2024
 ### Fixed
 - Fix bug in `patch_v2_components_dict` to properly handle response from `DB.get_all()`
 

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -300,9 +300,9 @@ def patch_v2_components_dict(data):
             if component_data:
                 components.append((component_id, component_data))
     else:
-        # On large scale systems, this response may be too large
-        # use v3 for smaller responses
-        components = DB.get_all()
+        # TODO: On large scale systems, this response may be too large
+        # and require paging to be implemented
+        components = [ (component_data["id"], component_data) for component_data, _ in DB.get_all() ]
 
     response = []
     patch = data.get("patch", {})


### PR DESCRIPTION
https://github.com/Cray-HPE/config-framework-service/pull/119 for CSM 1.6

Also fixes the fact that this call to DB.get_all was not updated to reflect the fact that it now returns a tuple, after the advent of pagination.