### PR TITLE
CASMCMS-8964: Bump connexion version to prevent false schema errors being logged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Dependencies
+- Bump `connexion` from `2.6.0` to `2.14.2` to pick up bug fixes to prevent false schema errors being logged.
+- Bump `Werkzeug` from `0.15.5` to `1.0.1` to meet `connexion` requirements.
 
 ## [1.12.7] - 4/5/2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.12.8] - 4/9/2024
 ### Dependencies
 - Bump `connexion` from `2.6.0` to `2.14.2` to pick up bug fixes to prevent false schema errors being logged.
 - Bump `Werkzeug` from `0.15.5` to `1.0.1` to meet `connexion` requirements.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -753,7 +753,7 @@ components:
               type: string
               description: The name of the CFS session that last configured the component.
           additionalProperties: false
-          writeOnly: true         
+          writeOnly: true
         desiredConfig:
           type: string
           description: A reference to a configuration

--- a/constraints.txt
+++ b/constraints.txt
@@ -7,7 +7,7 @@ cffi==1.12.2
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-connexion==2.6.0
+connexion==2.14.2
 cryptography==41.0.2
 Flask==1.0.4
 google-auth==1.6.1
@@ -39,6 +39,6 @@ swagger-ui-bundle==0.0.6
 typed-ast==1.3.1
 urllib3==1.25.9
 websocket-client==0.54.0
-Werkzeug==0.15.5
+Werkzeug==1.0.1
 wrapt==1.11.1
 testtools==2.3.0


### PR DESCRIPTION
I noticed some CFS errors being logged in Kubernetes, but saw no associated problems being caused by them. The errors I saw were:
```text
ERROR   - connexion.operations.openapi3 - Body property 'stateAppend' not defined in body schema
```

I tracked it down a bug in the `connexion` Python module I found the version we need to go to to pick up the fix for it. I've reviewed the changelog and I don't see any breaking changes that will impact us, and I tested the changes on wasp and verified that is resolves the issue, that the `cmsdev` CFS test suite passes, and that a CFS session I ran succeeded without incident.