### PR TITLE
CASMCMS-8964: Bump connexion version to prevent false schema errors being logged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Dependencies
+- Bump `connexion` from `2.6.0` to `2.14.2` to pick up bug fixes to prevent false schema errors being logged.
+- Bump `Werkzeug` from `0.15.6` to `1.0.1` to meet `connexion` requirements.
 
 ## [1.19.3] - 04/05/2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.19.4] - 04/09/2024
 ### Dependencies
 - Bump `connexion` from `2.6.0` to `2.14.2` to pick up bug fixes to prevent false schema errors being logged.
 - Bump `Werkzeug` from `0.15.6` to `1.0.1` to meet `connexion` requirements.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1364,7 +1364,7 @@ components:
               type: string
               description: The name of the CFS session that last configured the component.
           additionalProperties: false
-          writeOnly: true         
+          writeOnly: true
         desiredConfig:
           type: string
           description: A reference to a configuration

--- a/constraints.txt
+++ b/constraints.txt
@@ -7,7 +7,7 @@ cffi==1.12.3
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-connexion==2.6.0
+connexion==2.14.2
 cryptography==41.0.2
 Flask==1.0.4
 google-auth==1.6.3
@@ -41,5 +41,5 @@ testtools==2.3.0
 typed-ast==1.3.5
 urllib3==1.25.11
 websocket-client==0.54.0
-Werkzeug==0.15.6
+Werkzeug==1.0.1
 wrapt==1.11.2


### PR DESCRIPTION
https://github.com/Cray-HPE/config-framework-service/pull/125 for CSM 1.6