### PR TITLE
CASMCMS-8966: Add missing special_parameters property to V3ConfigurationLayer schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.18.5] - 04/17/2024
 ### Fixed
 - Added missing `special_parameters` to `V3ConfigurationLayer` schema in API spec.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added missing `special_parameters` to `V3ConfigurationLayer` schema in API spec.
 
 ## [1.18.4] - 04/09/2024
 ### Dependencies

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1556,7 +1556,7 @@ components:
           writeOnly: true
       additionalProperties: false
     V3SourceCert:
-      description: Information on a configmap containing a CA certificate for authenticating to git          
+      description: Information on a configmap containing a CA certificate for authenticating to git
       type: object
       properties:
         configmap_name:
@@ -1642,7 +1642,7 @@ components:
           type: string
           description: The url to access the git content
         credentials:
-          $ref: '#/components/schemas/V3SourceCreateCredentials'          
+          $ref: '#/components/schemas/V3SourceCreateCredentials'
         ca_cert:
           $ref: '#/components/schemas/V3SourceCert'
       additionalProperties: false

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1161,6 +1161,17 @@ components:
             The configuration branch to use.  This will automatically set commit to master on the branch
             when the configuration is added.
           pattern: '^[^\s;]*$'
+        special_parameters:
+          type: object
+          description: |
+            Optional parameters that do not affect the configuration content or are only used in
+            special circumstances.
+          properties:
+            ims_require_dkms:
+              type: boolean
+              description: |
+                If true, any image customization sessions that use this configuration will enable DKMS in IMS.
+          additionalProperties: false
       required: [playbook]
       additionalProperties: false
     V2Configuration:


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/config-framework-service/pull/129 for CSM 1.5