### PR TITLE
CASMCMS-8060 Fix incomplete non-root cray-cfs-api changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add missing pod securityContext
 
 ## [1.19.5] - 04/17/2024
 ### Fixed

--- a/kubernetes/cray-cfs-api/templates/database.yaml
+++ b/kubernetes/cray-cfs-api/templates/database.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -55,6 +55,9 @@ spec:
       labels:
         app.kubernetes.io/name: "{{ include "cray-service.name" . }}-db"
     spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 65534
       containers:
       - name: "{{ include "cray-service.name" . }}-db"
         image: "{{ .Values.database.image.repository }}:{{ .Values.database.image.tag }}"


### PR DESCRIPTION
## Summary and Scope

When the "cray-cfs-api" chart was converted to non-root, the change was incomplete.  In addition to specifying a "securityContext" for the container, a "securityContext" also needs to be specified for the pod.  This is what tells Kubernetes how to set up permissions on PVCs.  Without that, the PVCs will have the default permissions of the underlying storage class, which can vary between storage classes.

The only reason things are currently working is because the CephFS storage class defaults to a top level directory of "root/root", mode "0x777".  In Mercury we switch to a cStor storage class, where the default permissions are "0x755", and non-root containers are not able to create files.


## Issues and Related PRs

* Resolves [CASMCMS-8060](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8060)

## Testing

### Tested on:

  * Mercury

### Test description:

Without this change the chart fails to deploy on Mercury systems.  After patching the chart with this change, `cray-cfs-api` successfully deploys.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
There should be no visible changes, other than inside the running container the PVC mount point should no longer be owned by root.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

