### PR TITLE
CASMCMS-8978: Fix broken _matches_filter call in patch_v2_components_dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.19.5] - 04/17/2024
 ### Fixed
 - Fix broken `_matches_filter` call in `patch_v2_components_dict`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix broken `_matches_filter` call in `patch_v2_components_dict`.
 
 ## [1.19.5] - 04/17/2024
 ### Fixed


### PR DESCRIPTION
The fix for [CASMTRIAGE-5974](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5974) modified the `_matches_filter` function in `src/server/cray/cfs/api/controllers/components.py`, adding the `id_list` argument. (PR: https://github.com/Cray-HPE/config-framework-service/pull/82). However, it overlooked the call to this function in the `patch_v2_components_dict` function. So now that function raises an exception when it tries to make that call, due to the omitted argument.

Originally, this PR just modified the call so that it included all of the required arguments. But while that did allow my PATCH requests to succeed, I noticed that they were modifying more components than they should be. This led me to discover that there is a bug in the status filtering code for v2 -- specifically, the `_set_status` function is not used, and so the filter is not being correctly applied. This PR corrects that as well.

Backport for CSM 1.5:
https://github.com/Cray-HPE/config-framework-service/pull/134

Partial backport for CSM 1.4:
https://github.com/Cray-HPE/config-framework-service/pull/135
(the original bug does not exist in CSM 1.4, but the status filtering issue does)

I tested the CSM 1.5 changes on drax.
I tested the CSM 1.4 changes on wasp.