### PR TITLE
CASMCMS-9005: Bump minimum cray-services base chart version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bumped dependency versions to resolve CVEs
 | `urllib3`                | 1.25.11    | 1.26.19   |
 | `requests`               | 2.22.0     | 2.31.0    |
 | `idna`                   | 2.8        | 3.7       |
+| `setuptools`             | unpinned   | 65.5.1    |
 
 ## [1.19.5] - 04/17/2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 - CASMCMS-9005: Bump minimum `cray-services` base chart version from 7.0.0 to 10.0.5
-- Bump `certifi` from 2018.11.29 to 2023.7.22 to resolve CVE
+
+Bumped dependency versions to resolve CVEs
+
+| Package                  | From       | To        |
+|--------------------------|------------|-----------|
+| `certifi`                | 2018.11.29 | 2023.7.22 |
+| `urllib3`                | 1.25.11    | 1.26.19   |
+| `requests`               | 2.22.0     | 2.31.0    |
 
 ## [1.19.5] - 04/17/2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Add missing pod securityContext
+- Add missing pod `securityContext`
+
+### Dependencies
+- CASMCMS-9005: Bump minimum `cray-services` base chart version from 7.0.0 to 10.0.5
 
 ## [1.19.5] - 04/17/2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 - CASMCMS-9005: Bump minimum `cray-services` base chart version from 7.0.0 to 10.0.5
+- Bump `certifi` from 2018.11.29 to 2023.7.22 to resolve CVE
 
 ## [1.19.5] - 04/17/2024
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Bumped dependency versions to resolve CVEs
 | `certifi`                | 2018.11.29 | 2023.7.22 |
 | `urllib3`                | 1.25.11    | 1.26.19   |
 | `requests`               | 2.22.0     | 2.31.0    |
+| `idna`                   | 2.8        | 3.7       |
 
 ## [1.19.5] - 04/17/2024
 ### Fixed

--- a/constraints.txt
+++ b/constraints.txt
@@ -11,7 +11,7 @@ connexion==2.14.2
 cryptography==41.0.2
 Flask==1.0.4
 google-auth==1.6.3
-idna==2.8
+idna==3.7
 inflection==0.3.1
 isort==4.3.21
 itsdangerous==0.24

--- a/constraints.txt
+++ b/constraints.txt
@@ -36,6 +36,7 @@ PyYAML==6.0.1
 requests==2.31.0
 requests-oauthlib==1.0.0
 rsa==4.7.2
+setuptools==65.5.1
 swagger-ui-bundle==0.0.6
 testtools==2.3.0
 typed-ast==1.3.5

--- a/constraints.txt
+++ b/constraints.txt
@@ -2,7 +2,7 @@ adal==1.2.7
 asn1crypto==0.24.0
 astroid==2.2.5
 cachetools==3.0.0
-certifi==2018.11.29
+certifi==2023.7.22
 cffi==1.12.3
 chardet==3.0.4
 click==6.7

--- a/constraints.txt
+++ b/constraints.txt
@@ -33,13 +33,13 @@ PyJWT==1.7.1
 pylint==2.3.1
 python-dateutil==2.6.1
 PyYAML==6.0.1
-requests==2.22.0
+requests==2.31.0
 requests-oauthlib==1.0.0
 rsa==4.7.2
 swagger-ui-bundle==0.0.6
 testtools==2.3.0
 typed-ast==1.3.5
-urllib3==1.25.11
+urllib3==1.26.19
 websocket-client==0.54.0
 Werkzeug==1.0.1
 wrapt==1.11.2

--- a/kubernetes/cray-cfs-api/Chart.yaml
+++ b/kubernetes/cray-cfs-api/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,7 @@ sources:
 - https://github.com/Cray-HPE/config-framework-service
 dependencies:
 - name: cray-service
-  version: ^7.0.0
+  version: ~10.0.5
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts/
 maintainers:
 - name: rbak-hpe


### PR DESCRIPTION
Per the PET team, we need to move up to this version in CSM 1.6 or we'll be broken. I installed this on mug and saw no problems.

I also had to bump some dependency versions to calm Snyk down.