### PR TITLE
CASMCMS-9055: Update API spec to reflect the actual allowed formats for the age/TTL field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.7] - 07/23/2024
 ### Changed
 - Update API spec to reflect the actual allowed formats for the age/TTL fields.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Update API spec to reflect the actual allowed formats for the age/TTL fields.
+
 ## [1.18.6] - 05/07/2024
 ### Fixed
 - Fix broken `_matches_filter` call in `patch_v2_components_dict`.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -427,7 +427,10 @@ components:
           example: cfs-default-ansible-cfg
         sessionTTL:
           type: string
-          description: A time-to-live applied to all completed CFS sessions.  Specified in hours or days. e.g. 3d or 24h.  Set to an empty string to disable.
+          description: >
+            A time-to-live applied to all completed CFS sessions.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
+            Set to an empty string to disable.
           example: 24h
         additionalInventoryUrl:
           type: string
@@ -498,7 +501,10 @@ components:
           maxLength: 60
         session_ttl:
           type: string
-          description: A time-to-live applied to all completed CFS sessions.  Specified in hours or days. e.g. 3d or 24h.  Set to an empty string to disable.
+          description: >
+            A time-to-live applied to all completed CFS sessions.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
+            Set to an empty string to disable.
           example: 24h
           minLength: 0
           maxLength: 10
@@ -1786,22 +1792,28 @@ paths:
         - name: age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Return only sessions older than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
             DEPRECATED: This field has been replaced by min_age and max_age
         - name: min_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Return only sessions older than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: max_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions younger than the given age.  Age is given in the format "1d" or "6h"
+            Return only sessions younger than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: status
           schema:
             type: string
@@ -1872,22 +1884,28 @@ paths:
         - name: age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Deletes only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Deletes only sessions older than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
             DEPRECATED: This field has been replaced by min_age and max_age
         - name: min_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Deletes only sessions older than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: max_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions younger than the given age.  Age is given in the format "1d" or "6h"
+            Deletes only sessions younger than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: status
           schema:
             type: string
@@ -1914,7 +1932,7 @@ paths:
             type: string
           in: query
           description: >-
-            Return only sessions whose have the matching tags.  Key-value pairs should be separated using =,
+            Deletes only sessions whose have the matching tags.  Key-value pairs should be separated using =,
             and tags can be a comma-separated list. Only sessions that match all tags will be deleted.
       description:
         Delete multiple configuration sessions.  If filters are provided, only sessions matching
@@ -2312,15 +2330,19 @@ paths:
         - name: min_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Return only sessions older than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: max_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions younger than the given age.  Age is given in the format "1d" or "6h"
+            Return only sessions younger than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: status
           schema:
             type: string
@@ -2391,15 +2413,19 @@ paths:
         - name: min_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Deletes only sessions older than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: max_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions younger than the given age.  Age is given in the format "1d" or "6h"
+            Deletes only sessions younger than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: status
           schema:
             type: string


### PR DESCRIPTION
No changes to fields that impact the service itself -- only to informational fields.