### PR TITLE
CASMCMS-9055: Update API spec to reflect the actual allowed formats for the age/TTL field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Update API spec to reflect the actual allowed formats for the age/TTL fields.
+
 ## [1.12.9] - 5/7/2024
 ### Fixed
 - Fixed broken status filtering in `patch_v2_components_dict`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.10] - 7/23/2024
 ### Changed
 - Update API spec to reflect the actual allowed formats for the age/TTL fields.
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -303,7 +303,10 @@ components:
           example: cfs-default-ansible-cfg
         sessionTTL:
           type: string
-          description: A time-to-live applied to all completed CFS sessions.  Specified in hours or days. e.g. 3d or 24h.  Set to an empty string to disable.
+          description: >
+            A time-to-live applied to all completed CFS sessions.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
+            Set to an empty string to disable.
           example: 24h
         additionalInventoryUrl:
           type: string
@@ -942,22 +945,28 @@ paths:
         - name: age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Return only sessions older than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
             DEPRECATED: This field has been replaced by min_age and max_age
         - name: min_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Return only sessions older than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: max_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions younger than the given age.  Age is given in the format "1d" or "6h"
+            Return only sessions younger than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: status
           schema:
             type: string
@@ -1026,22 +1035,28 @@ paths:
         - name: age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Deletes only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Deletes only sessions older than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
             DEPRECATED: This field has been replaced by min_age and max_age
         - name: min_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions older than the given age.  Age is given in the format "1d" or "6h"
+            Deletes only sessions older than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: max_age
           schema:
             type: string
+            example: 24h
           in: query
           description: >-
-            Return only sessions younger than the given age.  Age is given in the format "1d" or "6h"
+            Deletes only sessions younger than the given age.
+            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
         - name: status
           schema:
             type: string
@@ -1068,7 +1083,7 @@ paths:
             type: string
           in: query
           description: >-
-            Return only sessions whose have the matching tags.  Key-value pairs should be separated using =,
+            Deletes only sessions whose have the matching tags.  Key-value pairs should be separated using =,
             and tags can be a comma-separated list. Only sessions that match all tags will be deleted.
       description:
         Delete multiple configuration sessions.  If filters are provided, only sessions matching


### PR DESCRIPTION
No changes to fields that impact the service itself -- only to informational fields.