### PR TITLE
CASMCMS-9189: Component-related corrections to API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- CASMCMS-9189: Two corrections to the CFS API spec
+  - The spec indicated that PUT requests to the `/components` endpoints could specify either a dictionary or a list, just as with PATCH requests to those endpoints.
+    However, the server code for the PUT endpoints only handled the list case. The API spec has been updated to reflect this reality.
+  - The spec allowed for components whose ID fields were set to 0-length strings, which should never be the case. There are some cases where the schema should permit
+    the field to be omitted entirely, but it should never be set to a 0-length string.
 
 ## [1.20.2] - 09/09/2024
 ### Changes

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -144,6 +144,20 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V3Options'
+    V2ComponentsCreateRequest:
+      description: The configuration/state for an array of components
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V2ComponentStateArray'
+    V3ComponentsCreateRequest:
+      description: The configuration/state for an array of components
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V3ComponentDataArray'
     V2ComponentsUpdateRequest:
       description: The configuration/state for an array of components
       required: true
@@ -1252,6 +1266,10 @@ components:
         next:
           $ref: '#/components/schemas/V3NextData'
     ## COMPONENTS ENDPOINT ##
+    ComponentId:
+      type: string
+      description: The component's id. e.g. xname for hardware components
+      minLength: 1
     V2ComponentsFilter:
       description: Information for patching multiple components.
       type: object
@@ -1356,8 +1374,7 @@ components:
       type: object
       properties:
         id:
-          type: string
-          description: The component's id. e.g. xname for hardware components
+          $ref: '#/components/schemas/ComponentId'
         state:
           type: array
           items:
@@ -1423,8 +1440,7 @@ components:
       type: object
       properties:
         id:
-          type: string
-          description: The component's id. e.g. xname for hardware components
+          $ref: '#/components/schemas/ComponentId'
         state:
           type: array
           items:
@@ -1521,7 +1537,7 @@ components:
         component_ids:
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/ComponentId'
     V2ComponentsUpdate:
       description: Information for patching multiple components.
       type: object
@@ -2094,7 +2110,7 @@ paths:
       description: Update the state for a collection of components in the cfs database
       operationId: put_components_v2
       requestBody:
-        $ref: '#/components/requestBodies/V2ComponentsUpdateRequest'
+        $ref: '#/components/requestBodies/V2ComponentsCreateRequest'
       responses:
         200:
           $ref: '#/components/responses/V2ComponentDetailsArray'
@@ -2648,7 +2664,7 @@ paths:
       description: Update the state for a collection of components in the cfs database
       operationId: put_components_v3
       requestBody:
-        $ref: '#/components/requestBodies/V3ComponentsUpdateRequest'
+        $ref: '#/components/requestBodies/V3ComponentsCreateRequest'
       responses:
         200:
           $ref: '#/components/responses/V3ComponentIdCollection'


### PR DESCRIPTION
[CASMTRIAGE-7462](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7462) was opened because a CFS component ended up being created with an empty string as its ID, and this caused issues. There are several aspects to this problem, and this PR addresses one of them. Specifically, it corrects some errors in the CFS API spec, one of which led to the described problem being possible.

1. When doing a PUT request to the `/components` endpoints, the spec allowed you to specify components whose ID fields were set to 0 length strings. This is how the problem described earlier came about. This PR updates the spec so that the ID field is a non-0 length string. Note that the spec still allows for the field to be omitted entirely. This is okay, because:
    1. The code that handles creating components WILL error out if the ID field is entirely absent. It just doesn't handle the case where it is an empty string.
    2. There are other cases where this same schema rightfully allows the ID field to be omitted -- for example, in the `patch` field of a components PATCH request.

1. I noticed when making the above change that the API spec actually allows for 2 types of request bodies when making PUT requests to create multiple components -- a dict or a list, just like what the PATCH components requests allow. However, the server code itself for the PUT endpoints does not handle the dict case, only the list case. And it makes sense, because per the spec, the dict format allows you to specify a `patch` and a `filter`. But when creating new components, it doesn't make sense to specify a filter. 

   That said, it would make sense to allow a dict-type PUT request where one field is just an ID list, and the other field is the body of the component data. That would allow much smaller requests when creating large numbers of components, like on large scale systems. But because this would be a more involved change, I think it is better to save for a different PR. This PR just removes the "dict" option from the API spec for the PUT endpoints, since it isn't actually implemented, and wouldn't really make sense anyway as-is.

I have tested this change on mug and verified that cfs-hwsync-agent is still able to create new components without issue, and other CFS operations that I attempted worked as expected.