### PR TITLE
CASMCMS-9196: Use default value for authentication_method when creating a source, if not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Do not make database call to look for configuration with null name
 
+### Fixed
+- CASMCMS-9196: Use the default value for `authentication_method` when creating a source, if the request does not specify it.
+
 ## [1.21.0] - 11/06/2024
 ### Fixed
 - CASMCMS-9189: Two corrections to the CFS API spec

--- a/src/server/cray/cfs/api/controllers/sources.py
+++ b/src/server/cray/cfs/api/controllers/sources.py
@@ -127,6 +127,13 @@ def post_source_v3():
             status=400, title="Error parsing the data provided.",
             detail=str(err))
 
+    # CASMCMS-9196: connexion does not fill in default values for parameters in the request
+    # body. So here we set the default value for authentication_method, if needed. Note that
+    # connexion DOES validate that the request is valid, so we know that the credentials field
+    # is present.
+    if "authentication_method" not in data["credentials"]:
+        data["credentials"]["authentication_method"] = "password"
+
     error = _validate_source(data)
     if error:
         return error


### PR DESCRIPTION
If you try to use the CFS API to create a source without specifying the `authentication_method` field, CFS hits an exception. CFS assumes that because the API spec sets a default value for this field, that connexion will automatically set it if needed. This is not the case. connexion validates the request body against the schema, but it does not set default values. This PR adds code to set the default value for this field, if it is omitted. I tested these changes on mug and verified that they correct the problem.

For CSM 1.7 I want to make a more general fix for this, where for any incoming request body, we consult the spec and fill in defaults as needed. I already have a simple function to do this, but even though it's simple, it's not as simple as the tiny change in this PR. For the CSM 1.5 and 1.6 patch releases, probably best to minimize the changes.