### PR TITLE
CASMCMS-9197: Only calculate in_use list if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Do not make database call to look for configuration with null name
+- CASMCMS-9197: Bypass needless code when listing configurations and sources
 
 ### Fixed
 - CASMCMS-9196: Use the default value for `authentication_method` when creating a source, if the request does not specify it.

--- a/src/server/cray/cfs/api/controllers/sources.py
+++ b/src/server/cray/cfs/api/controllers/sources.py
@@ -21,6 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+from collections.abc import Container
 import connexion
 from datetime import datetime
 from functools import partial
@@ -58,23 +59,26 @@ def get_sources_v3(in_use=None, limit=1, after_id=""):
 
 @options.defaults(limit="default_page_size")
 def _get_sources_data(in_use=None, limit=1, after_id=""):
-    source_filter = partial(_source_filter, in_use=in_use, in_use_list=_get_in_use_list())
+    # CASMCMS-9197: Only specify a filter if we are actually filtering
+    if in_use is not None:
+        source_filter = partial(_source_filter, in_use=in_use, in_use_list=_get_in_use_list())
+    else:
+        source_filter = None
     source_data_page, next_page_exists = DB.get_all(limit=limit, after_id=after_id, data_filter=source_filter)
     return source_data_page, next_page_exists
 
 
-def _source_filter(source_data, in_use, in_use_list):
-    if in_use is not None:
-        return _matches_filter(source_data, in_use, in_use_list)
-    else:
-        # No filter is being used so all components are valid
-        return True
+def _source_filter(source_data: dict, in_use: bool, in_use_list: Container[str]) -> bool:
+    """
+    If in_use is true:
+        Returns True if the name of the specified source is in in_use_list,
+        Returns False otherwise
 
-
-def _matches_filter(source_data, in_use, in_use_list):
-    if in_use is not None and (source_data["name"] in in_use_list) != in_use:
-            return False
-    return True
+    If in_use is false:
+        Returns True if the name of the specified source is NOT in in_use_list,
+        Returns False otherwise
+    """
+    return (source_data["name"] in in_use_list) == in_use
 
 
 def _get_in_use_list():


### PR DESCRIPTION
Currently, when asking CFS to list sources or configurations, CFS will always calculate the list of sources or configurations that are in use, whether or not you are filtering on that basis. On systems with a large number of CFS components, this can add almost a minute to the request time. This PR modifies the code so that the in_use lists are only created when they are actually necessary. I have tested on mug and verified that this reduces the huge performance penalty when listing without that filter specified, but that it does not break the ability to filter on that basis.