### PR TITLE
CASMCMS-9198: Enforce same value restrictions on CFS options between v2 and v3 (for options that exist in both)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - CASMCMS-9196: Use the default value for `authentication_method` when creating a source, if the request does not specify it.
+- CASMCMS-9198: Enforce same value restrictions on CFS options between v2 and v3 (for options that exist in both).
 
 ## [1.21.0] - 11/06/2024
 ### Fixed

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -411,64 +411,34 @@ components:
       type: object
       properties:
         hardwareSyncInterval:
-          type: integer
-          description: How frequently the CFS hardware-sync-agent checks with the Hardware State Manager to update its known hardware (in seconds)
-          example: 5
+          $ref: '#/components/schemas/V3Options/properties/hardware_sync_interval'
         batcherCheckInterval:
-          type: integer
-          description: How frequently the batcher checks the configuration states to see if work needs to be done (in seconds)
-          example: 5
+          $ref: '#/components/schemas/V3Options/properties/batcher_check_interval'
         batchSize:
-          type: integer
-          description: The maximum number of nodes the batcher will run a single CFS session against.
-          example: 120
+          $ref: '#/components/schemas/V3Options/properties/batch_size'
         batchWindow:
-          type: integer
-          description: The maximum number of seconds the batcher will wait to run a CFS session once a node has been detected that needs configuration.
-          example: 120
+          $ref: '#/components/schemas/V3Options/properties/batch_window'
         defaultBatcherRetryPolicy:
-          type: integer
-          description: The default maximum number retries per node when configuration fails.
-          example: 1
+          $ref: '#/components/schemas/V3Options/properties/default_batcher_retry_policy'
         defaultPlaybook:
           type: string
           description: The default playbook to be used if not specified in a node's desired state.
           example: site.yml
           pattern: '^[^\s;]*$'
         defaultAnsibleConfig:
-          type: string
-          description: The Kubernetes ConfigMap which holds the default ansible.cfg for a given CFS session. This ConfigMap must be present in the same Kubernetes namespace as the CFS service.
-          example: cfs-default-ansible-cfg
+          $ref: '#/components/schemas/V3Options/properties/default_ansible_config'
         sessionTTL:
-          type: string
-          description: >
-            A time-to-live applied to all completed CFS sessions.
-            Specified in minutes, hours, days, or weeks. e.g. 3d or 24h.
-            Set to an empty string to disable.
-          example: 24h
-          pattern: '^(?:[0-9]+[mMhHdDwW]){0,1}$'
-          minLength: 0
-          maxLength: 10
+          $ref: '#/components/schemas/V3Options/properties/session_ttl'
         additionalInventoryUrl:
-          type: string
-          description: >
-            The git clone URL of a repo with additional inventory files.  All files in the repo will be copied into the hosts directory of CFS.
-          example: https://api-gw-service-nmn.local/vcs/cray/inventory.git
-          pattern: '^[^\s;]*$'
+          $ref: '#/components/schemas/V3Options/properties/additional_inventory_url'
         batcherMaxBackoff:
-          type: integer
-          description: >
-            The maximum number of seconds that batcher will backoff from session creation if problems are detected.
-          example: 3600
+          $ref: '#/components/schemas/V3Options/properties/batcher_max_backoff'
         batcherDisable:
-          type: boolean
-          description: Disables cfs-batcher's automatic session creation if set to True.
+          $ref: '#/components/schemas/V3Options/properties/batcher_disable'
         batcherPendingTimeout:
-          type: integer
-          description: How long cfs-batcher will wait on a pending session before deleting and recreating it (in seconds).
+          $ref: '#/components/schemas/V3Options/properties/batcher_pending_timeout'
         loggingLevel:
-          type: string
-          description: The logging level for core CFS services.  This does not affect the Ansible logging level.
+          $ref: '#/components/schemas/V3Options/properties/logging_level'
       additionalProperties: false
     V3Options:
       description: |


### PR DESCRIPTION
Currently, for options that exist in both CFS v2 and v3, the API spec places more restrictions on the values that options can take in v3. I discovered this when the v2 endpoint let me set the logging level to 'debug', which is not a valid value per the V3 spec. This then caused CFS to hit a CLBO.

This PR modifies the API spec so that the V2 options follow the same value restrictions as the V3 options (for those that exist in both). I have tested this on mug and verified that it resolves the problem described (by preventing invalid values from being set).