### PR TITLE
CASMCMS-9200: Make Options class thread-safe and prevent redundant initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- CASMCMS-9200: Make Options class thread-safe and prevent redundant initialization
 
 ## [1.22.0] - 11/13/2024
 ### Changed


### PR DESCRIPTION
While doing other work, I noticed occasional Exceptions in the CFS server pod logs.  It was a `TypeError` generated by [this line of code](https://github.com/Cray-HPE/config-framework-service/blob/e3f3702bbda61f06674a7577520ef54968e43c66/src/server/cray/cfs/api/controllers/options.py#L152).

The specific error was:

`TypeError: 'NoneType' object is not subscriptable`

That got me looking at the `Options` class, and I started to suspect some thread safety issues, possibly related to the singleton implementation. There definitely is a possible race condition that results in more than one thread getting into the critical block in the `__new__` method. But even aside from that, it still ends up calling the `__init__` method every time the class is instantiated, even though it is a singleton. This is because after the call to `__new__`, Python itself automatically calls `__init__`. I tested this with some toy code and verified that this always happens.

Just to make certain, I added a debug logging call to both the `__init__` and the `refresh` methods, to see how often they were being called in practice. In a single pod, over around 150 seconds, the refresh method was called over 15000 times -- about 100 times per second. This is a result of the `__init__` method being called repeatedly, thus forcing the `refresh` method to be called repeatedly.

This PR fixes these thread safety and performance issues. A lock is added to the `__new__` method, ensuring that only one thread gets into the critical section at a time. But this lock is only taken if the class has not yet been instantiated, to avoid the relatively expensive operation of taking the lock. Inside the lock, we check again to make sure that the class has not yet been instantiated, and if it has not, go ahead and initialize it.

Two other aspects to the fix:

1. The `instance` class attribute is only updated at the very end of the critical section. That way, no other thread will see it has been set and try to use it before we are done setting it up.

2. The `__init__` method has been modified so that by default, it does NOT clear out the options data. It only does this if a specific parameter has been passed into it. And this parameter is ONLY passed into it when it is called from inside the `__new__` method. This guarantees that even though the `__init__` method is called repeatedly (automatically, by Python), it will only actually set the `options` value to `None` when it is first instantiated.

After making these changes, I tested this on mug, and verified that it worked fine. I also added back in my debug log statements and verified that with these changes, in a single pod in 150 seconds, the `refresh` method was called 99 times.