### PR TITLE
CASMCMS-9202: Add POST option to v3/sources/{source_id} endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CASMCMS-9202: Add POST option to v3/sources/{source_id} endpoint to allow restoring a previous
+  source by specifying its Vault secret name rather than a username/password.
 
 ## [1.22.0] - 11/13/2024
 ### Changed

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -211,6 +211,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/V3SourceCreateData'
+    V3SourceRestoreRequest:
+      description: A source
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/V3SourceRestoreData'
     V3SourceUpdateRequest:
       description: A source
       required: true
@@ -1614,15 +1621,34 @@ components:
         username:
           type: string
           description: The username for authenticating to git
+          minLength: 1
           writeOnly: true
         password:
           type: string
           description: The password for authenticating to git
+          minLength: 1
           writeOnly: true
       additionalProperties: false
       required:
         - username
         - password
+    V3SourceRestoreCredentials:
+      description: Information on a secret containing the username and password for accessing the git content
+      type: object
+      properties:
+        authentication_method:
+          type: string
+          description: The git authentication method used.
+          enum:
+            - password
+        secret_name:
+          type: string
+          description: The name of the credentials vault secret.
+          minLength: 1
+      required:
+        - authentication_method
+        - secret_name
+      additionalProperties: false
     V3SourceCreateData:
       description: Information for retrieving git content from a source.
       type: object
@@ -1631,14 +1657,35 @@ components:
           type: string
           description: The name of the source.  This field is optional and will default to the clone_url if not specified.
           example: sample-source
+          minLength: 1
         description:
           type: string
           description: A user-defined description. This field is not used by CFS.
         clone_url:
           type: string
           description: The url to access the git content
+          minLength: 1
         credentials:
           $ref: '#/components/schemas/V3SourceCreateCredentials'
+        ca_cert:
+          $ref: '#/components/schemas/V3SourceCert'
+      additionalProperties: false
+      required:
+        - clone_url
+        - credentials
+    V3SourceRestoreData:
+      description: Information for retrieving git content from a source.
+      type: object
+      properties:
+        description:
+          type: string
+          description: A user-defined description. This field is not used by CFS.
+        clone_url:
+          type: string
+          description: The url to access the git content
+          minLength: 1
+        credentials:
+          $ref: '#/components/schemas/V3SourceRestoreCredentials'
         ca_cert:
           $ref: '#/components/schemas/V3SourceCert'
       additionalProperties: false
@@ -1655,6 +1702,7 @@ components:
         clone_url:
           type: string
           description: The url to access the git content
+          minLength: 1
         credentials:
           $ref: '#/components/schemas/V3SourceCredentials'
         ca_cert:
@@ -2942,6 +2990,29 @@ paths:
           $ref: '#/components/responses/BadRequest'
         404:
           $ref: '#/components/responses/ResourceNotFound'
+    post:
+      summary: Restore a source
+      tags:
+        - sources
+        - v3
+        - cli_ignore
+      x-openapi-router-controller: cray.cfs.api.controllers.sources
+      description:  >-
+        Restore a CFS source by providing the name of the Vault secret that contains the credentials.
+        This does NOT create the secret in Vault, nor does it validate that the secret exists.
+        This is intended to be used to restore CFS data in the case that it is lost or corrupted.
+        This will NOT recover a source that has been deleted using CFS, because when CFS deletes a
+        source, it also deletes its corresponding Vault secret.
+      operationId: restore_source_v3
+      requestBody:
+        $ref: '#/components/requestBodies/V3SourceRestoreRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/V3SourceData'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        409:
+          $ref: '#/components/responses/ConflictingSourceName'
     delete:
       tags:
         - sources


### PR DESCRIPTION
When a Source is created using CFS v3, it takes a specified username and password, saves them under a Vault secret, and then resulting CFS source listing has that Vault secret name, not the username and password.

However, there is currently no way to create a source in CFS and specify the Vault secret name instead of the username and password. For regular use, this makes sense, but this ability is needed for the backup/restore case. I discussed this with Ryan and he agreed this isn't possible without modifying the API.

At first I considered just updating the current endpoint used to create sources, and having it allow either case. The only downside for that the two code paths are fairly different -- a lot of things are required for the create code path that are superfluous for the restore code path (even though it is also ultimately creating a source in CFS).

Currently, to create a new source, one does a POST to `v3/sources`. Specifying a source name is optional, because CFS will pick one for you if needed.

This PR adds another POST action, but this time to `v3/sources/{source_name}`. This is because in the restore case, the source name is already known, so it makes sense to specify it in the URL. I was going to use a PUT operation, but my understanding is that those are supposed to be idempotent, and that is not the case here (because the `last_updated` field of the source is set automatically by CFS, and would be different on repeated PUTs).

I set this new option to be ignored by the CLI, because it is specifically being added for the backup/restore tooling, which will use the API. Admins are of course free to use it via the API if they desire, but it doesn't seem like a common enough operation that it makes sense to put in the CLI. In any case, if there is demand for that, it would be easy enough to do.

I tested this new endpoint on mug and verified that I am able to create new sources using it.

This PR also specifies some minimum lengths for some source input fields, to avoid things like sources being created with empty names. The only fields where this is done is ones where the server code is written in a way that it clearly expects them to always be non-empty values, if they are present.