### PR TITLE
CASMCMS-9206: Update API spec to reflect that in v3, a layer requires exactly one of clone_url and source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- CASMCMS-9206: Update API spec to reflect that in v3, a layer requires exactly one of `clone_url` and `source`.
 
 ## [1.23.1] - 11/14/2024
 ### Added

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1058,6 +1058,8 @@ components:
     V3AdditionalInventoryLayer:
       description: |
         An inventory reference to include in a set of configurations.
+        Either clone_url or source must be specified -- it is required to specify one,
+        but they are mutually exclusive.
       type: object
       properties:
         name:
@@ -1084,7 +1086,6 @@ components:
             The repository branch to use. This will automatically set `commit` to master on the branch
             when the configuration is added.
           pattern: '^[^\s;]*$'
-      required: [clone_url]
       additionalProperties: false
     V2ConfigurationLayer:
       description: |
@@ -1131,6 +1132,8 @@ components:
     V3ConfigurationLayer:
       description: |
         A single desired configuration state for a component.
+        Either clone_url or source must be specified -- it is required to specify one,
+        but they are mutually exclusive.
       type: object
       properties:
         name:


### PR DESCRIPTION
All layers (whether additional or normal) in CFS v3 require either clone_url or source to be set, but not both. The CFS server code makes this clear (and I have confirmed with Ryan). The spec, however, for additional inventory layers in v3, states that the clone_url field is required. This has the effect of making it impossible to create a configuration with an additional inventory layer that contains a source field. If you try to specify both source and clone_url, then the server balks. If you try to specify just source, then connexion stops you, because it violates the spec.

This PR updates the spec to remove the requirement for clone_url specifically, and also updates the V3 layer descriptions to explicitly state that the fields are mutually exclusive, but one is required.

I have tested this on mug and verified that with it in place, I am now able to create configurations that have additional inventories with sources specified. I also verified that I am still prevented from creating additional inventories without source or clone_url specified.