### PR TITLE
CASMCMS-9210: Correctly check additional_inventory layer when seeing if a source is in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- CASMCMS-9210: Correctly check `additional_inventory` layer when seeing if a source is in use
 
 ## [1.23.4] - 11/15/2024
 ### Fixed

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -149,7 +149,7 @@ def put_configuration_v2(configuration_id):
             status=400, title="Error parsing the data provided.",
             detail=str(err))
 
-    for layer in _iter_layers(data, include_additional_inventory=True):
+    for layer in iter_layers(data, include_additional_inventory=True):
         if 'branch' in layer and 'commit' in layer:
             return connexion.problem(
                 status=400, title="Error handling error branches",
@@ -163,7 +163,7 @@ def put_configuration_v2(configuration_id):
             detail=str(e))
 
     layer_keys = set()
-    for layer in _iter_layers(data, include_additional_inventory=False):
+    for layer in iter_layers(data, include_additional_inventory=False):
         layer_key = (layer.get('clone_url'), layer.get('playbook'))
         if layer_key in layer_keys:
             return connexion.problem(
@@ -187,7 +187,7 @@ def put_configuration_v3(configuration_id, drop_branches=False):
             status=400, title="Error parsing the data provided.",
             detail=str(err))
 
-    for layer in _iter_layers(data, include_additional_inventory=True):
+    for layer in iter_layers(data, include_additional_inventory=True):
         if 'clone_url' in layer and 'source' in layer:
             return connexion.problem(
                 status=400, title="Error handling source",
@@ -213,7 +213,7 @@ def put_configuration_v3(configuration_id, drop_branches=False):
             detail=str(e))
 
     layer_keys = set()
-    for layer in _iter_layers(data, include_additional_inventory=False):
+    for layer in iter_layers(data, include_additional_inventory=False):
         layer_key = (layer.get('clone_url', layer.get('source')), layer.get('playbook'))
         if layer_key in layer_keys:
             return connexion.problem(
@@ -223,7 +223,7 @@ def put_configuration_v3(configuration_id, drop_branches=False):
         layer_keys.add(layer_key)
 
     if drop_branches:
-        for layer in _iter_layers(data, include_additional_inventory=True):
+        for layer in iter_layers(data, include_additional_inventory=True):
             if "branch" in layer:
                 del(layer["branch"])
 
@@ -302,7 +302,7 @@ def delete_configuration_v3(configuration_id):
     return DB.delete(configuration_id), 204
 
 
-def _iter_layers(config_data, include_additional_inventory=True):
+def iter_layers(config_data, include_additional_inventory=True):
     if include_additional_inventory and config_data.get("additional_inventory"):
         for layer in (config_data.get('layers') + [config_data.get('additional_inventory')]):
             yield layer
@@ -334,7 +334,7 @@ class BranchConversionException(Exception):
 
 
 def _convert_branches_to_commits(data):
-    for layer in _iter_layers(data, include_additional_inventory=True):
+    for layer in iter_layers(data, include_additional_inventory=True):
         if 'branch' in layer:
             branch = layer.get('branch')
             if 'source' in layer:

--- a/src/server/cray/cfs/api/controllers/sources.py
+++ b/src/server/cray/cfs/api/controllers/sources.py
@@ -87,10 +87,7 @@ def _get_in_use_list():
     if source:
         in_use_list.add(source)
     for configuration in _iter_configurations_data():
-        source = configuration.get("additional_inventory_source", "")
-        if source and type(source) == str:
-            in_use_list.add(source)
-        for layer in configuration.get("layers"):
+        for layer in configurations.iter_layers(configuration, include_additional_inventory=True):
             source = layer.get("source", "")
             if source:
                 in_use_list.add(source)


### PR DESCRIPTION
When listing CFS v3 sources, you can choose to filter on those which are in use. Also, when deleting a source, it automatically checks to see if it is in use.

In both cases, the same underlying function is used to determine whether or not it is in use. This function has a bug. It has to check 3 places to determine whether or not a source is in use:

1. The `additional_inventory_source` CFS option
2. Each standard `layer` in each CFS configuration
3. The `additional_inventory` layer in each CFS configuration

The bug is with the third one. The logic that does the check looks in the CFS configuration for a field named `additional_inventory_source`, and acts like it should be the name of a source. In truth, the field is named `additional_inventory`, and it points to an object which may or may not have a `source` field set.

This PR modifies the checking function to fix this bug. To simplify things, it uses a function defined in the configurations controller to iterate over all layers in a CFS configuration (regular AND additional), checking each for a source name.

I have tested this on mug and verified that it fixes the problem.