### PR TITLE
CASMCMS-9211: Improve performance of configuration delete operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-9211: Improve performance of configuration delete operation.
 
 ## [1.23.4] - 11/15/2024
 ### Fixed

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -114,6 +114,11 @@ def _iter_components_data():
         if not next_parameters:
             break
 
+def _config_in_use(config_name: str) -> bool:
+    data, _ = components.get_components_v3(config_name=config_name, limit=1)
+    if data["components"]:
+        return True
+    return False
 
 @dbutils.redis_error_handler
 def get_configuration_v2(configuration_id):
@@ -278,7 +283,7 @@ def delete_configuration_v2(configuration_id):
         return connexion.problem(
             status=404, title="Configuration not found",
             detail="Configuration {} could not be found".format(configuration_id))
-    if configuration_id in _get_in_use_list():
+    if _config_in_use(configuration_id):
         return connexion.problem(
             status=400, title="Configuration is in use.",
             detail="Configuration {} is referenced by the desired state of"
@@ -294,7 +299,7 @@ def delete_configuration_v3(configuration_id):
         return connexion.problem(
             status=404, title="Configuration not found",
             detail="Configuration {} could not be found".format(configuration_id))
-    if configuration_id in _get_in_use_list():
+    if _config_in_use(configuration_id):
         return connexion.problem(
             status=400, title="Configuration is in use.",
             detail="Configuration {} is referenced by the desired state of"


### PR DESCRIPTION
When a CFS configuration is deleted, it checks to make sure it is not in use before deleting it. The method it uses to do this is to look at every component and make a list of every configuration that is in use, and then see if this particular configuration is in that list. This has the virtue of reusing code, but it can take a long time. On a large scale system like mug, the delete operation took over 35 seconds.

This PR improves that procedure in two ways:
1. Instead of listing all components, it queries specifically for components that have that particular configuration as their desired configuration. This means that the filtering for relevant components happens much closer to the database calls.
2. When doing that query, set a limit of 1. That means that CFS will respond to us after it finds a single matching component. We only care whether any such components exist and have no interest in the full list, so this is better for us.

I tested this on mug. After making these changes, deleting an unused configuration took 13 seconds, and attempting to delete an in-use configuration took 2 seconds (previously even this case took 35 seconds).
