### PR TITLE
CASMCMS-9150: Update API autoscaler apiVersion to support upgraded Kubernetes in CSM 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.0] - 01/13/2025
+### Changed
+- CASMCMS-9150: Update API autoscaler `apiVersion` to support upgraded Kubernetes in CSM 1.7.
+
 ## [1.23.5] - 11/15/2024
 ### Changed
 - CASMCMS-9211: Improve performance of configuration delete operation.

--- a/kubernetes/cray-cfs-api/templates/api-autoscaler.yaml
+++ b/kubernetes/cray-cfs-api/templates/api-autoscaler.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2022, 2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 */}}
 {{- $baseChartValues := index .Values "cray-service" -}}
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: "{{ include "cray-service.name" . }}"


### PR DESCRIPTION
Per @studenym-hpe , we need to update this `apiVersion` in order to work with the upgraded Kubernetes in CSM 1.7.