### PR TITLE
Feature/casmcms 9228: CRUD Enhancements for multi-tenancy Operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CASMCMS-9228: Added common core utilities from BOS' for retry resiliency and tapms tenancy functions
+- CASMCMS-9228: Added multitenancy features to the configurations endpoint.
+### Changed
+- CASMCMS-9228: Converted database get features to support multiple filters
 
 ## [1.23.5] - 11/15/2024
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9228: Added multitenancy features to the configurations endpoint.
 ### Changed
 - CASMCMS-9228: Converted database get features to support multiple filters
+### Dependencies
+- CASMCMS-9288: Use centralized requests_retry_session
 
 ## [1.23.5] - 11/15/2024
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9228: Added multitenancy features to the configurations endpoint.
 ### Changed
 - CASMCMS-9228: Converted database get features to support multiple filters
+- CASMCMS-9228: Updated base alpine image for a newer version of python
 ### Dependencies
 - CASMCMS-9288: Use centralized requests_retry_session
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9228: Added multitenancy features to the configurations endpoint.
 ### Changed
 - CASMCMS-9228: Converted database get features to support multiple filters
-- CASMCMS-9228: Updated base alpine image for a newer version of python
 ### Dependencies
 - CASMCMS-9288: Use centralized requests_retry_session
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN cat lib/server/requirements.txt && \
     pip3 install --no-cache-dir -r requirements.txt && \
     pip3 list --format freeze
 COPY src/server/cray/cfs/api/controllers lib/server/cray/cfs/api/controllers
-COPY src/server/cray/cfs/api/utils       lib/server/cray/cfs/api/utils
+COPY src/server/cray/cfs/utils           lib/server/cray/cfs/utils
 COPY src/server/cray/cfs/api/__main__.py \
      src/server/cray/cfs/api/__init__.py \
      src/server/cray/cfs/api/dbutils.py \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY constraints.txt requirements.txt ./
 # The openapi-generator creates a requirements file that specifies exactly Flask==2.1.1
 # However, using Flask 2.2.5 is also compatible, and resolves a CVE.
 # Accordingly, we relax their requirements file.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     cat lib/server/requirements.txt && \
     sed -i 's/Flask == 2\(.*\)$/Flask >= 2\1\nFlask < 3/' lib/server/requirements.txt && \
@@ -52,7 +53,7 @@ RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     pip3 list --format freeze && \
     pip3 install --no-cache-dir -U pip && \
     pip3 list --format freeze && \
-    pip3 install --no-cache-dir -r requirements.txt --break-system-packages && \
+    pip3 install --no-cache-dir -r requirements.txt && \
     pip3 list --format freeze
 COPY src/server/cray/cfs/__init__.py     lib/server/cray/cfs
 COPY src/server/cray/cfs/api/controllers lib/server/cray/cfs/api/controllers

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN /usr/local/bin/docker-entrypoint.sh generate \
     -c config/autogen-server.json
 
 # Base image
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3 as base
 WORKDIR /app
 COPY --from=codegen /app .
 COPY constraints.txt requirements.txt ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ RUN cat lib/server/requirements.txt && \
     pip3 list --format freeze && \
     pip3 install --no-cache-dir -r requirements.txt && \
     pip3 list --format freeze
+COPY src/server/cray/cfs/__init__.py     lib/server/cray/cfs
 COPY src/server/cray/cfs/api/controllers lib/server/cray/cfs/api/controllers
-COPY src/server/cray/cfs/utils           lib/server/cray/cfs/utils
 COPY src/server/cray/cfs/api/__main__.py \
      src/server/cray/cfs/api/__init__.py \
      src/server/cray/cfs/api/dbutils.py \
@@ -63,6 +63,7 @@ COPY src/server/cray/cfs/api/__main__.py \
      src/server/cray/cfs/api/vault_utils.py \
      src/server/cray/cfs/api/migrations.py \
      lib/server/cray/cfs/api/
+COPY src/server/cray/cfs/utils           lib/server/cray/cfs/utils
 
 # Application Image
 FROM base as application

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ COPY constraints.txt requirements.txt ./
 # The openapi-generator creates a requirements file that specifies exactly Flask==2.1.1
 # However, using Flask 2.2.5 is also compatible, and resolves a CVE.
 # Accordingly, we relax their requirements file.
-RUN cat lib/server/requirements.txt && \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    cat lib/server/requirements.txt && \
     sed -i 's/Flask == 2\(.*\)$/Flask >= 2\1\nFlask < 3/' lib/server/requirements.txt && \
     cat lib/server/requirements.txt && \
     apk add --upgrade --no-cache apk-tools &&  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     pip3 list --format freeze && \
     pip3 install --no-cache-dir -U pip && \
     pip3 list --format freeze && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+    pip3 install --no-cache-dir -r requirements.txt --break-system-packages && \
     pip3 list --format freeze
 COPY src/server/cray/cfs/__init__.py     lib/server/cray/cfs
 COPY src/server/cray/cfs/api/controllers lib/server/cray/cfs/api/controllers

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN cat lib/server/requirements.txt && \
     pip3 install --no-cache-dir -r requirements.txt && \
     pip3 list --format freeze
 COPY src/server/cray/cfs/api/controllers lib/server/cray/cfs/api/controllers
+COPY src/server/cray/cfs/api/utils       lib/server/cray/cfs/api/utils
 COPY src/server/cray/cfs/api/__main__.py \
      src/server/cray/cfs/api/__init__.py \
      src/server/cray/cfs/api/dbutils.py \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,14 +34,13 @@ RUN /usr/local/bin/docker-entrypoint.sh generate \
     -c config/autogen-server.json
 
 # Base image
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3 as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as base
 WORKDIR /app
 COPY --from=codegen /app .
 COPY constraints.txt requirements.txt ./
 # The openapi-generator creates a requirements file that specifies exactly Flask==2.1.1
 # However, using Flask 2.2.5 is also compatible, and resolves a CVE.
 # Accordingly, we relax their requirements file.
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     cat lib/server/requirements.txt && \
     sed -i 's/Flask == 2\(.*\)$/Flask >= 2\1\nFlask < 3/' lib/server/requirements.txt && \

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -81,8 +81,8 @@ pipeline {
                         DOCKER_ARGS = getDockerBuildArgs(name: env.NAME, description: env.DESCRIPTION, version: env.DOCKER_VERSION)
                     }
 
-                    steps {
-                        sh "make image"
+                 withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                    sh "make image"
                     }
                 }
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -51,14 +51,12 @@ pipeline {
                 cloneCMSMetaTools()
             }
         }
-
         stage("Set Versions") {
             steps {
                 // This function is defined in cms-meta-tools:vars/setVersionFiles.groovy
                 setVersionFiles()
             }
         }
-
         stage("Build Prep") {
             steps {
                  withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
@@ -66,14 +64,12 @@ pipeline {
                     }
             }
         }
-
         stage("Lint") {
             steps {
                 sh "make lint"
             }
         }
-
-        stage("Build") {
+        stage("Build Image and Chart") {
             parallel {
                 stage('Image') {
                     environment {
@@ -81,11 +77,11 @@ pipeline {
                         DOCKER_ARGS = getDockerBuildArgs(name: env.NAME, description: env.DESCRIPTION, version: env.DOCKER_VERSION)
                     }
 
-                 withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
-                    sh "make image"
+                    steps {
+                        echo "Docker args are ${env.DOCKER_ARGS}"
+                        sh "make image"
                     }
                 }
-
                 stage('Chart') {
                     environment {
                         DOCKER_VERSION = sh(returnStdout: true, script: "head -1 .docker_version").trim()

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -82,9 +82,7 @@ pipeline {
                     }
 
                     steps {
-                        withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
-                            sh "make image"
-                        }
+                        sh "make image"
                     }
                 }
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -82,7 +82,9 @@ pipeline {
                     }
 
                     steps {
-                        sh "make image"
+                        withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                            sh "make image"
+                        }
                     }
                 }
 

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ CHART_VERSION ?= $(shell head -1 .chart_version)
 
 HELM_UNITTEST_IMAGE ?= quintush/helm-unittest:3.3.0-0.2.5
 
+ifneq ($(wildcard ${HOME}/.netrc),)
+	DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
+endif
+
 all : runbuildprep lint image chart
 chart: chart_setup chart_package chart_test
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1216,6 +1216,11 @@ components:
         description:
           type: string
           description: A user-defined description. This field is not used by CFS.
+        tenant_name:
+          type: string
+          description: The name of a tenant that owns this set of configuration.
+          example: blue-tenant
+          required: false
         last_updated:
           type: string
           description: The date/time when the state was last updated in RFC 3339 format.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1220,7 +1220,6 @@ components:
           type: string
           description: The name of a tenant that owns this set of configuration.
           example: blue-tenant
-          readOnly: true
         last_updated:
           type: string
           description: The date/time when the state was last updated in RFC 3339 format.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1220,7 +1220,7 @@ components:
           type: string
           description: The name of a tenant that owns this set of configuration.
           example: blue-tenant
-          required: false
+          readOnly: true
         last_updated:
           type: string
           description: The date/time when the state was last updated in RFC 3339 format.

--- a/constraints.txt
+++ b/constraints.txt
@@ -35,6 +35,7 @@ PyYAML>=6.0.1,<6.1
 redis>=5.0,<5.1
 requests>=2.31,<2.32
 requests-oauthlib>=1.3.1,<1.4
+requests-retry-session>=0.1,<0.2
 rsa>=4.7.2,<4.8
 swagger-ui-bundle==0.0.9
 testtools>=2.3,<2.4

--- a/constraints.txt
+++ b/constraints.txt
@@ -7,6 +7,7 @@ cffi>=1.12,<1.13
 chardet>=3.0,<3.1
 click>=8.1.7,<8.2
 clickclick>=20.10.2,<20.11
+connexion>=2.14.2,<2.15
 cryptography>=41.0,<41.1
 Flask>=2.2.5,<2.3
 google-auth>=2.16.3,<2.17

--- a/constraints.txt
+++ b/constraints.txt
@@ -7,7 +7,6 @@ cffi>=1.12,<1.13
 chardet>=3.0,<3.1
 click>=8.1.7,<8.2
 clickclick>=20.10.2,<20.11
-connexion>=2.14.2,<2.15
 cryptography>=41.0,<41.1
 Flask>=2.2.5,<2.3
 google-auth>=2.16.3,<2.17

--- a/constraints.txt
+++ b/constraints.txt
@@ -35,7 +35,7 @@ PyYAML>=6.0.1,<6.1
 redis>=5.0,<5.1
 requests>=2.31,<2.32
 requests-oauthlib>=1.3.1,<1.4
-requests-retry-session>=2.0,<2.1
+requests-retry-session>=1.0,<1.1
 rsa>=4.7.2,<4.8
 swagger-ui-bundle==0.0.9
 testtools>=2.3,<2.4

--- a/constraints.txt
+++ b/constraints.txt
@@ -35,7 +35,7 @@ PyYAML>=6.0.1,<6.1
 redis>=5.0,<5.1
 requests>=2.31,<2.32
 requests-oauthlib>=1.3.1,<1.4
-requests-retry-session>=0.1,<0.2
+requests-retry-session>=2.0,<2.1
 rsa>=4.7.2,<4.8
 swagger-ui-bundle==0.0.9
 testtools>=2.3,<2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --trusted-host artifactory.algol60.net
---index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
+--extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 -c constraints.txt
 -r lib/server/requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+--trusted-host arti.hpc.amslabs.hpecorp.net
+--trusted-host artifactory.algol60.net
+--index-url https://arti.hpc.amslabs.hpecorp.net:443/artifactory/api/pypi/pypi-remote/simple
 --extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 -c constraints.txt
 -r lib/server/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 -c constraints.txt
 -r lib/server/requirements.txt
 
@@ -7,6 +8,7 @@ redis
 kafka-python
 ujson
 hvac
+requests-retry-session
 
 # The purpose of this file is to contain python runtime requirements
 # for controller code, e.g., code authored by developers, as opposed to

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
---trusted-host arti.hpc.amslabs.hpecorp.net
 --trusted-host artifactory.algol60.net
---index-url https://arti.hpc.amslabs.hpecorp.net:443/artifactory/api/pypi/pypi-remote/simple
---extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
+--index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 -c constraints.txt
 -r lib/server/requirements.txt
 

--- a/src/server/cray/cfs/__init__.py
+++ b/src/server/cray/cfs/__init__.py
@@ -1,0 +1,23 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -149,10 +149,11 @@ def get_components_data(id_list=[], status_list=[], enabled=None, config_name=""
     Allows filtering using a comma separated list of ids.
     """
     configs = configurations.Configurations()
-    component_filter = partial(_component_filter, config_details=config_details, configs=configs,
+    filters = []
+    filters.append(partial(_component_filter, config_details=config_details, configs=configs,
                                id_list=id_list, status_list=status_list, enabled=enabled,
-                               config_name=config_name, tag_list=tag_list)
-    component_data_page, next_page_exists = DB.get_all(limit=limit, after_id=after_id, data_filter=component_filter)
+                               config_name=config_name, tag_list=tag_list))
+    component_data_page, next_page_exists = DB.get_all(limit=limit, after_id=after_id, data_filters=filters)
     return component_data_page, next_page_exists
 
 

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -37,7 +37,7 @@ from cray.cfs.api.controllers import sources
 from cray.cfs.api.k8s_utils import get_configmap as get_kubernetes_configmap
 from cray.cfs.api.vault_utils import get_secret as get_vault_secret
 from cray.cfs.api.models.v2_configuration import V2Configuration # noqa: E501
-from cray.cfs.utils.multitenancy import get_tenant_from_header, get_tenant_aware_key, reject_invalid_tenant
+from cray.cfs.utils.multitenancy import get_tenant_from_header, reject_invalid_tenant
 
 LOGGER = logging.getLogger('cray.cfs.api.controllers.configurations')
 DB = dbutils.get_wrapper(db='configurations')

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -244,6 +244,7 @@ def put_configuration_v3(configuration_id, drop_branches=False):
     # If the configuration already exists, and the tenant is not owned by the requesting put tenant, then we cannot
     # allow them to overwrite the existing data for this key.
     existing_configuration = DB.get(configuration_id) or {}
+    LOGGER.debug("Requesting Tenant: '%s'; Existing Configuration: '%s'" %(requesting_tenant, existing_configuration))
     if all([requesting_tenant is not None,
             existing_configuration.get('tenant_name', None) != requesting_tenant]):
         return TENANT_FORBIDDEN_OPERATION

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -243,7 +243,7 @@ def put_configuration_v3(configuration_id, drop_branches=False):
 
     # If the configuration already exists, and the tenant is not owned by the requesting put tenant, then we cannot
     # allow them to overwrite the existing data for this key.
-    existing_configuration = DB.get(configuration_id)
+    existing_configuration = DB.get(configuration_id) or False
     if all([requesting_tenant,
             existing_configuration,
             existing_configuration.get('tenant_name', '') != requesting_tenant]):

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -243,9 +243,9 @@ def put_configuration_v3(configuration_id, drop_branches=False):
 
     # If the configuration already exists, and the tenant is not owned by the requesting put tenant, then we cannot
     # allow them to overwrite the existing data for this key.
-    existing_configuration = DB.get(configuration_id) or False
+    existing_configuration = DB.get(configuration_id)
     if all([requesting_tenant,
-            existing_configuration,
+            existing_configuration is not None,
             existing_configuration.get('tenant_name', '') != requesting_tenant]):
         return TENANT_FORBIDDEN_OPERATION
 

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -85,9 +85,7 @@ def get_configurations_v3(in_use=None, limit=1, after_id=""):
     """Used by the GET /configurations API operation"""
     LOGGER.debug("GET /configurations invoked get_configurations")
     called_parameters = locals()
-    tenant = get_tenant_from_header()
-    if not tenant:
-        tenant = None
+    tenant = get_tenant_from_header() or None
     configurations_data, next_page_exists = _get_configurations_data(in_use=in_use, limit=limit, after_id=after_id,
                                                                      tenant=tenant)
     response = {"configurations": configurations_data, "next": None}
@@ -179,7 +177,7 @@ def get_configuration_v3(configuration_id):
         return connexion.problem(status=404, title="Configuration not found",
                                         detail="Configuration {} could not be found".format(configuration_id))
     configuration_data = DB.get(configuration_id)
-    tenant = get_tenant_from_header()
+    tenant = get_tenant_from_header() or None
     if all([tenant,
             tenant != configuration_data.get('tenant_name', '')]):
         return TENANT_FORBIDDEN_OPERATION
@@ -254,7 +252,8 @@ def put_configuration_v3(configuration_id, drop_branches=False):
         data['tenant_name'] = requesting_tenant
     else:
         # The global admin is requesting the change; they can do everything, including putting over other people's
-        # stuff.
+        # stuff. This block is split out specifically for this comment, which is why we have it even though it is just
+        # a pass.
         pass
 
     for layer in iter_layers(data, include_additional_inventory=True):

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,12 +37,34 @@ from cray.cfs.api.controllers import sources
 from cray.cfs.api.k8s_utils import get_configmap as get_kubernetes_configmap
 from cray.cfs.api.vault_utils import get_secret as get_vault_secret
 from cray.cfs.api.models.v2_configuration import V2Configuration # noqa: E501
+from cray.cfs.api.utils.multitenancy import get_tenant_from_header, get_tenant_aware_key, reject_invalid_tenant
 
 LOGGER = logging.getLogger('cray.cfs.api.controllers.configurations')
 DB = dbutils.get_wrapper(db='configurations')
 SOURCES_DB = dbutils.get_wrapper(db='sources')
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
+def _get_filtered_configurations(tenant):
+    response = DB.get_all()
+    if any([tenant]):
+        response = [r for r in response if _matches_filter(r, tenant)]
+    return response
+
+
+def _matches_filter(data, tenant):
+    if tenant and tenant != data.get("tenant_name"):
+        return False
+    return True
+
+# Common Multitenancy specific connection responses
+TENANT_FORBIDDEN_OPERATION = connexion.problem(
+    status=403, title="Forbidden operation.",
+    detail="Tenant does not own the requested resources and is forbidden from making changes."
+)
+IMMUTABLE_TENANT_NAME_FIELD = connexion.problem(
+    status=403, title="Forbidden operation.",
+    detail="Modification to existing field 'tenant_name' is not permitted."
+)
 
 @dbutils.redis_error_handler
 def get_configurations_v2(in_use=None):
@@ -58,11 +80,16 @@ def get_configurations_v2(in_use=None):
 
 @dbutils.redis_error_handler
 @options.defaults(limit="default_page_size")
+@reject_invalid_tenant
 def get_configurations_v3(in_use=None, limit=1, after_id=""):
     """Used by the GET /configurations API operation"""
     LOGGER.debug("GET /configurations invoked get_configurations")
     called_parameters = locals()
-    configurations_data, next_page_exists = _get_configurations_data(in_use=in_use, limit=limit, after_id=after_id)
+    tenant = get_tenant_from_header()
+    if not tenant:
+        tenant = None
+    configurations_data, next_page_exists = _get_configurations_data(in_use=in_use, limit=limit, after_id=after_id,
+                                                                     tenant=tenant)
     response = {"configurations": configurations_data, "next": None}
     if next_page_exists:
         next_data = called_parameters
@@ -72,18 +99,23 @@ def get_configurations_v3(in_use=None, limit=1, after_id=""):
 
 
 @options.defaults(limit="default_page_size")
-def _get_configurations_data(in_use=None, limit=1, after_id=""):
+def _get_configurations_data(in_use=None, limit=1, after_id="", tenant=None):
+    data_filters = []
     # CASMCMS-9197: Only specify a filter if we are actually filtering
     if in_use is not None:
-        configuration_filter = partial(_configuration_filter, in_use=in_use, in_use_list=_get_in_use_list())
-    else:
-        configuration_filter = None
-    configuration_data_page, next_page_exists = DB.get_all(limit=limit, after_id=after_id, data_filter=configuration_filter)
+        data_filters.append(partial(_configuration_filter, in_use=in_use, in_use_list=_get_in_use_list()))
+    if tenant:
+        # In the event a tenant is not set, the super administrator should be able to view configurations owned by ALL
+        # tenants. As such, we only reduce the effective set of configurations down when a tenant admin is requesting.
+        data_filters.append(partial(_tenancy_filter, tenant=tenant))
+    configuration_data_page, next_page_exists = DB.get_all(limit=limit, after_id=after_id, data_filters=data_filters)
     return configuration_data_page, next_page_exists
 
 
 def _configuration_filter(configuration_data: dict, in_use: bool, in_use_list: Container[str]) -> bool:
     """
+    The purpose of this function is to filter CFS configurations that are referenced by any defined component.
+
     If in_use is true:
         Returns True if the name of the specified configuration is in in_use_list,
         Returns False otherwise
@@ -93,6 +125,13 @@ def _configuration_filter(configuration_data: dict, in_use: bool, in_use_list: C
         Returns False otherwise
     """
     return (configuration_data["name"] in in_use_list) == in_use
+
+
+def _tenancy_filter(configuration_data: dict, tenant: str) -> bool:
+    """
+    The purpose of this function is to reduce the total number of configurations to just those owned by an individual tenant.
+    """
+    return configuration_data.get('tenant_name', '') == tenant
 
 
 def _get_in_use_list():
@@ -132,13 +171,18 @@ def get_configuration_v2(configuration_id):
 
 
 @dbutils.redis_error_handler
+@reject_invalid_tenant
 def get_configuration_v3(configuration_id):
     """Used by the GET /configurations/{configuration_id} API operation"""
     LOGGER.debug("GET /configurations/id invoked get_configuration")
     if configuration_id not in DB:
-        return connexion.problem(
-            status=404, title="Configuration not found",
-            detail="Configuration {} could not be found".format(configuration_id))
+        return connexion.problem(status=404, title="Configuration not found",
+                                        detail="Configuration {} could not be found".format(configuration_id))
+    configuration_data = DB.get(configuration_id)
+    tenant = get_tenant_from_header()
+    if all([tenant,
+            tenant != configuration_data.get('tenant_name', '')]):
+        return TENANT_FORBIDDEN_OPERATION
     return DB.get(configuration_id), 200
 
 
@@ -182,6 +226,7 @@ def put_configuration_v2(configuration_id):
 
 
 @dbutils.redis_error_handler
+@reject_invalid_tenant
 def put_configuration_v3(configuration_id, drop_branches=False):
     """Used by the PUT /configurations/{configuration_id} API operation"""
     LOGGER.debug("PUT /configurations/id invoked put_configuration")
@@ -191,6 +236,30 @@ def put_configuration_v3(configuration_id, drop_branches=False):
         return connexion.problem(
             status=400, title="Error parsing the data provided.",
             detail=str(err))
+
+    # If the put request comes from a specific tenant, make note of it in the record -- we're going to use it in
+    # subsequent data puts and permission checks.
+    requesting_tenant = get_tenant_from_header()
+
+    # If the configuration already exists, and the tenant is not owned by the requesting put tenant, then we cannot
+    # allow them to overwrite the existing data for this key.
+    existing_configuration = DB.get(configuration_id)
+    if all([requesting_tenant,
+            existing_configuration,
+            existing_configuration.get('tenant_name', '') != requesting_tenant]):
+        return TENANT_FORBIDDEN_OPERATION
+
+    # If there is no associated tenant, then this is the global administrator. We will allow them to set the tenant_name
+    # so that they can create configurations for specific tenants. Otherwise, tenant_name is an immutable field that
+    # tenants are not allowed to modify via PUT.
+    if all([requesting_tenant,
+            data.get('tenant_name', ''),
+            data.get('tenant_name', '') != requesting_tenant]):
+        return IMMUTABLE_TENANT_NAME_FIELD
+
+    # The put request is valid, so append ownership to the datastructure.
+    if requesting_tenant:
+        data['tenant_name'] = requesting_tenant
 
     for layer in iter_layers(data, include_additional_inventory=True):
         if 'clone_url' in layer and 'source' in layer:
@@ -256,6 +325,7 @@ def patch_configuration_v2(configuration_id):
 
 
 @dbutils.redis_error_handler
+@reject_invalid_tenant
 def patch_configuration_v3(configuration_id):
     """Used by the PATCH /configurations/{configuration_id} API operation"""
     LOGGER.debug("PATCH /configurations/id invoked put_configuration")
@@ -264,6 +334,30 @@ def patch_configuration_v3(configuration_id):
             status=404, title="Configuration not found",
             detail="Configuration {} could not be found".format(configuration_id))
     data = DB.get(configuration_id)
+
+    # If the put request comes from a specific tenant, make note of it in the record -- we're going to use it in
+    # subsequent data puts and permission checks.
+    requesting_tenant = get_tenant_from_header()
+
+    # If the configuration already exists, and the tenant is not owned by the requesting put tenant, then we cannot
+    # allow them to overwrite the existing data for this key.
+    existing_configuration = DB.get(configuration_id)
+    if all([requesting_tenant,
+            existing_configuration,
+            existing_configuration.get('tenant_name', '') != requesting_tenant]):
+        return TENANT_FORBIDDEN_OPERATION
+
+    # If there is no associated tenant, then this is the global administrator. We will allow them to set the tenant_name
+    # so that they can create configurations for specific tenants. Otherwise, tenant_name is an immutable field that
+    # tenants are not allowed to modify via PUT.
+    if all([requesting_tenant,
+            data.get('tenant_name', ''),
+            data.get('tenant_name', '') != requesting_tenant]):
+        return IMMUTABLE_TENANT_NAME_FIELD
+
+    # The put request is valid, so append ownership to the datastructure.
+    if requesting_tenant:
+        data['tenant_name'] = requesting_tenant
 
     try:
         data = _set_auto_fields(data)
@@ -304,6 +398,16 @@ def delete_configuration_v3(configuration_id):
             status=400, title="Configuration is in use.",
             detail="Configuration {} is referenced by the desired state of"
                    "some components".format(configuration_id))
+    # If the put request comes from a specific tenant, make note of it in the record -- we're going to use it in
+    # subsequent data puts and permission checks.
+    requesting_tenant = get_tenant_from_header()
+    # If the configuration already exists, and the tenant is not owned by the requesting delete tenant, then we cannot
+    # allow them to overwrite the existing data for this key.
+    existing_configuration = DB.get(configuration_id)
+    if all([requesting_tenant,
+            existing_configuration,
+            existing_configuration.get('tenant_name', '') != requesting_tenant]):
+        return TENANT_FORBIDDEN_OPERATION
     return DB.delete(configuration_id), 204
 
 

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -239,12 +239,12 @@ def put_configuration_v3(configuration_id, drop_branches=False):
 
     # If the put request comes from a specific tenant, make note of it in the record -- we're going to use it in
     # subsequent data puts and permission checks.
-    requesting_tenant = get_tenant_from_header()
+    requesting_tenant = get_tenant_from_header() or None
 
     # If the configuration already exists, and the tenant is not owned by the requesting put tenant, then we cannot
     # allow them to overwrite the existing data for this key.
     existing_configuration = DB.get(configuration_id) or {}
-    if all([requesting_tenant,
+    if all([requesting_tenant is not None,
             existing_configuration.get('tenant_name', None) != requesting_tenant]):
         return TENANT_FORBIDDEN_OPERATION
 
@@ -336,21 +336,19 @@ def patch_configuration_v3(configuration_id):
 
     # If the put request comes from a specific tenant, make note of it in the record -- we're going to use it in
     # subsequent data puts and permission checks.
-    requesting_tenant = get_tenant_from_header()
+    requesting_tenant = get_tenant_from_header() or None
 
     # If the configuration already exists, and the tenant is not owned by the requesting put tenant, then we cannot
     # allow them to overwrite the existing data for this key.
-    existing_configuration = DB.get(configuration_id)
-    if all([requesting_tenant,
-            existing_configuration,
+    existing_configuration = DB.get(configuration_id) or {}
+    if all([requesting_tenant is not None,
             existing_configuration.get('tenant_name', '') != requesting_tenant]):
         return TENANT_FORBIDDEN_OPERATION
 
     # If there is no associated tenant, then this is the global administrator. We will allow them to set the tenant_name
     # so that they can create configurations for specific tenants. Otherwise, tenant_name is an immutable field that
     # tenants are not allowed to modify via PUT.
-    if all([requesting_tenant,
-            data.get('tenant_name', ''),
+    if all([requesting_tenant is not None,
             data.get('tenant_name', '') != requesting_tenant]):
         return IMMUTABLE_TENANT_NAME_FIELD
 
@@ -399,12 +397,11 @@ def delete_configuration_v3(configuration_id):
                    "some components".format(configuration_id))
     # If the put request comes from a specific tenant, make note of it in the record -- we're going to use it in
     # subsequent data puts and permission checks.
-    requesting_tenant = get_tenant_from_header()
+    requesting_tenant = get_tenant_from_header() or None
     # If the configuration already exists, and the tenant is not owned by the requesting delete tenant, then we cannot
     # allow them to overwrite the existing data for this key.
-    existing_configuration = DB.get(configuration_id)
-    if all([requesting_tenant,
-            existing_configuration,
+    existing_configuration = DB.get(configuration_id) or {}
+    if all([requesting_tenant is not None,
             existing_configuration.get('tenant_name', '') != requesting_tenant]):
         return TENANT_FORBIDDEN_OPERATION
     return DB.delete(configuration_id), 204

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -37,7 +37,7 @@ from cray.cfs.api.controllers import sources
 from cray.cfs.api.k8s_utils import get_configmap as get_kubernetes_configmap
 from cray.cfs.api.vault_utils import get_secret as get_vault_secret
 from cray.cfs.api.models.v2_configuration import V2Configuration # noqa: E501
-from cray.cfs.api.utils.multitenancy import get_tenant_from_header, get_tenant_aware_key, reject_invalid_tenant
+from cray.cfs.utils.multitenancy import get_tenant_from_header, get_tenant_aware_key, reject_invalid_tenant
 
 LOGGER = logging.getLogger('cray.cfs.api.controllers.configurations')
 DB = dbutils.get_wrapper(db='configurations')

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -243,18 +243,17 @@ def put_configuration_v3(configuration_id, drop_branches=False):
 
     # If the configuration already exists, and the tenant is not owned by the requesting put tenant, then we cannot
     # allow them to overwrite the existing data for this key.
-    existing_configuration = DB.get(configuration_id)
+    existing_configuration = DB.get(configuration_id) or {}
     if all([requesting_tenant,
-            existing_configuration is not None,
-            existing_configuration.get('tenant_name', '') != requesting_tenant]):
+            existing_configuration.get('tenant_name', None) != requesting_tenant]):
         return TENANT_FORBIDDEN_OPERATION
 
     # If there is no associated tenant, then this is the global administrator. We will allow them to set the tenant_name
     # so that they can create configurations for specific tenants. Otherwise, tenant_name is an immutable field that
     # tenants are not allowed to modify via PUT.
-    if all([requesting_tenant,
-            data.get('tenant_name', ''),
-            data.get('tenant_name', '') != requesting_tenant]):
+    if all([requesting_tenant is not None, #A tenant admin is requesting...
+            data.get('tenant_name', None) != requesting_tenant # The existing data already has an established tenant...
+            ]):
         return IMMUTABLE_TENANT_NAME_FIELD
 
     # The put request is valid, so append ownership to the datastructure.

--- a/src/server/cray/cfs/api/controllers/sessions.py
+++ b/src/server/cray/cfs/api/controllers/sessions.py
@@ -668,8 +668,9 @@ def _validate_ansible_passthrough(passthrough):
 
 @options.defaults(limit="default_page_size")
 def _get_filtered_sessions(age, min_age, max_age, status, name_contains, succeeded, tag_list, limit=1, after_id=""):
-    session_filter = _get_session_filter(age, min_age, max_age, status, name_contains, succeeded, tag_list)
-    session_data_page, next_page_exists = DB.get_all(limit=limit, after_id=after_id, data_filter=session_filter)
+    filters = []
+    filters.append(_get_session_filter(age, min_age, max_age, status, name_contains, succeeded, tag_list))
+    session_data_page, next_page_exists = DB.get_all(limit=limit, after_id=after_id, data_filters=filters)
     return session_data_page, next_page_exists
 
 

--- a/src/server/cray/cfs/api/controllers/sources.py
+++ b/src/server/cray/cfs/api/controllers/sources.py
@@ -60,11 +60,10 @@ def get_sources_v3(in_use=None, limit=1, after_id=""):
 @options.defaults(limit="default_page_size")
 def _get_sources_data(in_use=None, limit=1, after_id=""):
     # CASMCMS-9197: Only specify a filter if we are actually filtering
+    filters = []
     if in_use is not None:
-        source_filter = partial(_source_filter, in_use=in_use, in_use_list=_get_in_use_list())
-    else:
-        source_filter = None
-    source_data_page, next_page_exists = DB.get_all(limit=limit, after_id=after_id, data_filter=source_filter)
+        filters.append(partial(_source_filter, in_use=in_use, in_use_list=_get_in_use_list()))
+    source_data_page, next_page_exists = DB.get_all(limit=limit, after_id=after_id, data_filters=filters)
     return source_data_page, next_page_exists
 
 

--- a/src/server/cray/cfs/utils/core_client.py
+++ b/src/server/cray/cfs/utils/core_client.py
@@ -49,7 +49,7 @@ class RetrySessionManager(rrs.RetrySessionManager):
 
     def __init__(self,
                  protocol: str = PROTOCOL,
-                 **adapter_kwargs:
+                 **adapter_kwargs)
         for key, value in DEFAULT_RETRY_ADAPTER_ARGS.items():
             if key not in adapter_kwargs:
                 adapter_kwargs[key] = value

--- a/src/server/cray/cfs/utils/core_client.py
+++ b/src/server/cray/cfs/utils/core_client.py
@@ -1,0 +1,90 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import traceback
+import requests
+import requests_retry_session as rrs
+
+
+
+PROTOCOL = 'http'
+
+
+DEFAULT_RETRY_ADAPTER_ARGS = rrs.RequestsRetryAdapterArgs(
+    retries=10,
+    backoff_factor=0.5,
+    status_forcelist=(500, 502, 503, 504),
+    connect_timeout=3,
+    read_timeout=10)
+
+retry_session_manager = partial(rrs.retry_session_manager,
+                                protocol=PROTOCOL,
+                                **DEFAULT_RETRY_ADAPTER_ARGS)
+
+
+class RetrySessionManager(rrs.RetrySessionManager):
+    """
+    Just sets the default values we use for our requests sessions
+    """
+
+    def __init__(self,
+                 protocol: str = PROTOCOL,
+                 **adapter_kwargs: Unpack[rrs.RequestsRetryAdapterArgs]):
+        for key, value in DEFAULT_RETRY_ADAPTER_ARGS.items():
+            if key not in adapter_kwargs:
+                adapter_kwargs[key] = value
+        super().__init__(protocol=protocol, **adapter_kwargs)
+
+
+def retry_session(
+    session: Optional[requests.Session] = None,
+    protocol: Optional[str] = None,
+    adapter_kwargs: Optional[rrs.RequestsRetryAdapterArgs] = None
+) -> Iterator[requests.Session]:
+    if session is not None:
+        return nullcontext(session)
+    kwargs = adapter_kwargs or {}
+    if protocol is not None:
+        return retry_session_manager(protocol=protocol, **kwargs)  # pylint: disable=redundant-keyword-arg
+    return retry_session_manager(**kwargs)
+
+
+def retry_session_get(*get_args,
+                      session: Optional[requests.Session] = None,
+                      protocol: Optional[str] = None,
+                      adapter_kwargs: Optional[
+                          rrs.RequestsRetryAdapterArgs] = None,
+                      **get_kwargs) -> Iterator[requests.Response]:
+    with retry_session(session=session,
+                       protocol=protocol,
+                       adapter_kwargs=adapter_kwargs) as _session:
+        return _session.get(*get_args, **get_kwargs)
+
+
+def exc_type_msg(exc: Exception) -> str:
+    """
+    Given an exception, returns a string of its type and its text
+    (e.g. TypeError: 'int' object is not subscriptable)
+    """
+    return ''.join(traceback.format_exception_only(type(exc), exc))

--- a/src/server/cray/cfs/utils/core_client.py
+++ b/src/server/cray/cfs/utils/core_client.py
@@ -25,12 +25,12 @@
 import traceback
 import requests
 import requests_retry_session as rrs
+from functools import partial
+from typing import Iterator, Optional, Unpack
 
 
 
 PROTOCOL = 'http'
-
-
 DEFAULT_RETRY_ADAPTER_ARGS = rrs.RequestsRetryAdapterArgs(
     retries=10,
     backoff_factor=0.5,

--- a/src/server/cray/cfs/utils/core_client.py
+++ b/src/server/cray/cfs/utils/core_client.py
@@ -29,7 +29,6 @@ from functools import partial
 from typing import Iterator, Optional, Unpack
 
 
-
 PROTOCOL = 'http'
 DEFAULT_RETRY_ADAPTER_ARGS = rrs.RequestsRetryAdapterArgs(
     retries=10,

--- a/src/server/cray/cfs/utils/core_client.py
+++ b/src/server/cray/cfs/utils/core_client.py
@@ -49,7 +49,7 @@ class RetrySessionManager(rrs.RetrySessionManager):
 
     def __init__(self,
                  protocol: str = PROTOCOL,
-                 **adapter_kwargs)
+                 **adapter_kwargs):
         for key, value in DEFAULT_RETRY_ADAPTER_ARGS.items():
             if key not in adapter_kwargs:
                 adapter_kwargs[key] = value

--- a/src/server/cray/cfs/utils/core_client.py
+++ b/src/server/cray/cfs/utils/core_client.py
@@ -26,7 +26,7 @@ import traceback
 import requests
 import requests_retry_session as rrs
 from functools import partial
-from typing import Iterator, Optional, Unpack
+from typing import Iterator, Optional
 
 
 PROTOCOL = 'http'
@@ -49,7 +49,7 @@ class RetrySessionManager(rrs.RetrySessionManager):
 
     def __init__(self,
                  protocol: str = PROTOCOL,
-                 **adapter_kwargs: Unpack[rrs.RequestsRetryAdapterArgs]):
+                 **adapter_kwargs:
         for key, value in DEFAULT_RETRY_ADAPTER_ARGS.items():
             if key not in adapter_kwargs:
                 adapter_kwargs[key] = value

--- a/src/server/cray/cfs/utils/multitenancy.py
+++ b/src/server/cray/cfs/utils/multitenancy.py
@@ -25,6 +25,7 @@
 import functools
 import logging
 import hashlib
+import requests
 
 import connexion
 from requests.exceptions import HTTPError

--- a/src/server/cray/cfs/utils/multitenancy.py
+++ b/src/server/cray/cfs/utils/multitenancy.py
@@ -31,7 +31,7 @@ from requests.exceptions import HTTPError
 from core_client import exc_type_msg, PROTOCOL, retry_session_get
 from typing import Optional
 
-LOGGER = logging.getLogger('cfs.utils.multitenancy')
+LOGGER = logging.getLogger('cfs.api.utils.multitenancy')
 
 TENANT_HEADER = "Cray-Tenant-Name"
 SERVICE_NAME = 'cray-tapms/v1alpha3' # CASMCMS-9125: Currently when TAPMS bumps this version, it

--- a/src/server/cray/cfs/utils/multitenancy.py
+++ b/src/server/cray/cfs/utils/multitenancy.py
@@ -1,0 +1,109 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import functools
+import logging
+import hashlib
+
+import connexion
+from requests.exceptions import HTTPError
+from core_client import exc_type_msg, PROTOCOL, retry_session_get
+from typing import Optional
+
+LOGGER = logging.getLogger('cfs.utils.multitenancy')
+
+TENANT_HEADER = "Cray-Tenant-Name"
+SERVICE_NAME = 'cray-tapms/v1alpha3' # CASMCMS-9125: Currently when TAPMS bumps this version, it
+                                     # breaks backwards compatiblity, so CFS needs to update this
+                                     # whenever TAPMS does.
+BASE_ENDPOINT = f"{PROTOCOL}://{SERVICE_NAME}"
+TENANT_ENDPOINT = f"{BASE_ENDPOINT}/tenants" # CASMPET-6433 changed this from tenant to tenants
+
+
+class InvalidTenantException(Exception):
+    pass
+
+
+def get_tenant_from_header():
+    tenant = ""
+    if TENANT_HEADER in connexion.request.headers:
+        tenant = connexion.request.headers[TENANT_HEADER]
+        if not tenant:
+            tenant = ""
+    return tenant
+
+def get_tenant_data(tenant, session: Optional[requests.Session] = None):
+    url = f"{TENANT_ENDPOINT}/{tenant}"
+    with retry_session_get(url, session=session) as response:
+        try:
+            response.raise_for_status()
+        except HTTPError as e:
+            LOGGER.error("Failed getting tenant data from tapms: %s",
+                         exc_type_msg(e))
+            if response.status_code == 404:
+                raise InvalidTenantException(
+                    f"Data not found for tenant {tenant}") from e
+            raise
+        return response.json()
+
+
+def validate_tenant_exists(tenant: str) -> bool:
+    try:
+        get_tenant_data(tenant)
+        return True
+    except InvalidTenantException:
+        return False
+
+
+def tenant_error_handler(func):
+    """Decorator for returning errors if there is an exception when calling tapms"""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except InvalidTenantException as e:
+            LOGGER.debug("Invalid tenant: %s", exc_type_msg(e))
+            return connexion.problem(status=400,
+                                     title='Invalid tenant',
+                                     detail=str(e))
+
+    return wrapper
+
+
+def reject_invalid_tenant(func):
+    """Decorator for preemptively validating the tenant exists"""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        tenant = get_tenant_from_header()
+        if tenant and not validate_tenant_exists(tenant):
+            LOGGER.debug("The provided tenant does not exist")
+            return connexion.problem(
+                status=400,
+                title="Invalid tenant",
+                detail=str("The provided tenant does not exist"))
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/src/server/cray/cfs/utils/multitenancy.py
+++ b/src/server/cray/cfs/utils/multitenancy.py
@@ -28,7 +28,7 @@ import hashlib
 
 import connexion
 from requests.exceptions import HTTPError
-from core_client import exc_type_msg, PROTOCOL, retry_session_get
+from cray.cfs.utils.core_client import exc_type_msg, PROTOCOL, retry_session_get
 from typing import Optional
 
 LOGGER = logging.getLogger('cfs.api.utils.multitenancy')


### PR DESCRIPTION
## Summary and Scope

In order for config framework service to leverage secure operations when launching configuration management using SOPS in conjunction with Hashicorp Vault, we need to record and make note of the owning tenant. More specifically, the global administrator needs full purview of the configurations that have been made in order to assist in audit and "gifting" of known good configuration for deployment. Doing so will allow a future follow on PR to `cfs-operator` to set tenant specific hashicorp vault unlock tokens during session creation.

Doing so during all session creation removes the ambiguity of session ownership because sessions can already require exactly one CFS configuration to use during these operations, so it is also possible for `cfs-operator` to negotiate the necessary time bound vault unlock token needed by Ansible to decrypt tenant specific sensitive variables used during BOTH image customization AND node personalization. This is notable because it allows sensitive information and information that has been secured using SOPS/Vault into an image.

## Issues and Related PRs

* Resolves [CASMCMS-9228](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9228)
* Change will also be needed in `cray-cfs-operator` as mentioned above.

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`
  * Local development environment

### Test description:

Deployed the updated chart to mug and then see if it works by running a serious of commands that exercise the creation (PUT), listing (get), and deletion of CFS Configurations, including the creation of a new tenant, creation of a new user, generating tokens for both admin and tenant admin users and testing the CRUD interactions above using a script.

## Risks and Mitigations

Low.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

