### PR TITLE
CASMCMS-9263: Improve CFS component query performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - CASMCMS-9263: Make database scanning more performant
+- CASMCMS-9263: Remove unnecessary calculations when filtering components
 
 ## [1.23.5] - 11/15/2024
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.23.6] - 01/29/2025
 ### Changed
 - CASMCMS-9263: Make database scanning more performant
 - CASMCMS-9263: Remove unnecessary calculations when filtering components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-9263: Make database scanning more performant
 
 ## [1.23.5] - 11/15/2024
 ### Changed

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -158,24 +158,17 @@ def get_components_data(id_list=[], status_list=[], enabled=None, config_name=""
 
 def _component_filter(component_data, config_details, configs,
                       id_list, status_list, enabled, config_name, tag_list):
+    # Before bothering to set status, check the filters which do not require it.
+    if id_list and not component_data.get("id") in id_list:
+        return False
+    if enabled is not None and component_data.get('enabled') != enabled:
+        return False
+    if config_name and component_data.get('desired_config') != config_name:
+        return False
+    if tag_list and any([component_data.get('tags', {}).get(k) != v for k, v in tag_list]):
+        return False
     _set_status(component_data, configs, config_details) # This sets the status both for filtering and for the response data
-    if id_list or status_list or (enabled is not None) or config_name or tag_list:
-        return _matches_filter(component_data, id_list, status_list, enabled, config_name, tag_list)
-    else:
-        # No filter is being used so all components are valid
-        return True
-
-
-def _matches_filter(data, id_list, status_list, enabled, config_name, tag_list):
-    if id_list and not data.get("id") in id_list:
-        return False
-    if status_list and not data.get('configuration_status') in status_list:
-        return False
-    if enabled is not None and data.get('enabled') != enabled:
-        return False
-    if config_name and data.get('desired_config') != config_name:
-        return False
-    if tag_list and any([data.get('tags', {}).get(k) != v for k, v in tag_list]):
+    if status_list and not component_data.get('configuration_status') in status_list:
         return False
     return True
 


### PR DESCRIPTION
On mug (~12000 nodes), I noticed that CFS batcher was not creating CFS sessions. Investigation revealed that it was hitting repeated timeouts when trying to query CFS for components. Even drastically lowering the page size did not fix the issue. Looking closer, I think this is similar to something I needed to change in BOS when I implemented paging there. Specifically, I had to change how it scanned through the Redis database. Currently CFS does individual DB gets for each component. This leads to it being very slow. Grabbing them in batches significantly improves performance.

I also noticed that the filter function sets the component status even before it needs to. A number of the filter options are ones which are un-impacted by the status update functions. Thus, we should only call the status update functions after those filters have first been checked, to avoid calculating status unnecessarily.

Prior to making any changes, the CFS query batcher was performing took 15-16 seconds to complete (which was consistently hitting the 10 second timeout).
After making just the database change, the time was 4-5 seconds.
After making both changes, the time was 3-4 seconds.
This is similar to the improvement I observed in BOS when I made the corresponding changes there with https://github.com/Cray-HPE/bos/pull/396