### PR TITLE
CASMCMS-9280: Fix syntax error in get_all method of dbutils

### DIFF
--- a/src/server/cray/cfs/api/dbutils.py
+++ b/src/server/cray/cfs/api/dbutils.py
@@ -104,8 +104,8 @@ class DBWrapper():
             for datastr in self.client.mget(all_keys[:500]):
                 yield json.loads(datastr) if datastr else None
             all_keys = all_keys[500:]
-      
-    def get_all(self, limit=0, after_id==None, data_filters=None):
+
+    def get_all(self, limit=0, after_id=None, data_filters=None):
         """Get an array of data for all keys."""
 
         if not data_filters:


### PR DESCRIPTION
This PR makes sure that the `develop` branch has the bug fix for this syntax error.

This bug does not exist in `master` branch, so I think it would be more confusing than anything else to add this to the CHANGELOG, because then it would look like version v1.25 has this bug, when it does not.

The current theory is that since Joel and I were both making changes to that same file, one of us made a mistake when resolving merge conflicts, resulting in this bug going into develop but not being there in master.