### PR TITLE
CASMCMS-9461: Restored accidentally-removed tenancy code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Added missing spaces in two error messages.
+- CASMCMS-9461: Restored accidentally-removed code in v3 configurations PUT endpoint that handled tenant information
 
 ## [1.26.1]
 ### Removed


### PR DESCRIPTION
In [the original PR that added tenancy support](https://github.com/Cray-HPE/config-framework-service/pull/167), the behavior of the v3 configuration PATCH endpoint was changed in a way that inappropriately altered how it behaved. This was [reverted in a later PR](https://github.com/Cray-HPE/config-framework-service/pull/179), but that PR also accidentally removed similar code from the v3 configuration PUT endpoint. That removal broke the ability to create configurations that are associated with tenants. This PR restores that accidentally-removed block of code.