### PR TITLE
CASMCMS-9463: Enforce tenancy restrictions on v3 configurations PATCH endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added missing spaces in two error messages.
 - CASMCMS-9461: Restored accidentally-removed code in v3 configurations PUT endpoint that handled tenant information
 - CASMCMS-9462: Document tenant header parameter in API spec
+- CASMCMS-9463: Enforce tenancy restrictions on v3 configurations PATCH endpoint
 
 ## [1.26.1]
 ### Removed

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -330,6 +330,11 @@ def patch_configuration_v3(configuration_id):
             detail="Configuration {} could not be found".format(configuration_id))
     data = DB.get(configuration_id)
 
+    tenant = get_tenant_from_header() or None
+    if all([tenant,
+            tenant != data.get('tenant_name', '')]):
+        return TENANT_FORBIDDEN_OPERATION
+
     try:
         data = _set_auto_fields(data)
     except BranchConversionException as e:


### PR DESCRIPTION
In [the original PR that added tenancy support](https://github.com/Cray-HPE/config-framework-service/pull/167), the behavior of the v3 configuration PATCH endpoint was changed in a way that inappropriately altered how it behaved. This was [reverted in a later PR](https://github.com/Cray-HPE/config-framework-service/pull/179), but that PR also accidentally entirely removed all of the code that made the v3 PATCH endpoint tenant-aware. That means any tenant is able to call this endpoint for any configuration, regardless of who owns it. Since the PATCH endpoint just updates the commits based on the specified branches in the layers (if applicable), this is not as bad as if this was the case for something like the DELETE endpoint. But it's still not something we want to be possible.

This PR adds the same basic tenancy check to the PATCH endpoint as is used in the other endpoints.