### PR TITLE
CASMCMS-9464: Document new API error responses introduced with tenancy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9461: Restored accidentally-removed code in v3 configurations PUT endpoint that handled tenant information
 - CASMCMS-9462: Document tenant header parameter in API spec
 - CASMCMS-9463: Enforce tenancy restrictions on v3 configurations PATCH endpoint
+- CASMCMS-9464: Document new API error responses introduced with tenancy support
 
 ## [1.26.1]
 ### Removed

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -369,6 +369,12 @@ components:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/ProblemDetails'
+    ForbiddenOperation:
+      description: The operation being attempted is not permitted.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
     ResourceNotFound:
       description: The resource was not found.
       content:
@@ -2864,6 +2870,10 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/V3ConfigurationData'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/ForbiddenOperation'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     put:
@@ -2889,6 +2899,8 @@ paths:
           $ref: '#/components/responses/V3ConfigurationData'
         400:
           $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/ForbiddenOperation'
     patch:
       summary: Update the commits for a configuration
       tags:
@@ -2902,6 +2914,8 @@ paths:
           $ref: '#/components/responses/V3ConfigurationData'
         400:
           $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/ForbiddenOperation'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     delete:
@@ -2919,6 +2933,8 @@ paths:
           $ref: '#/components/responses/ResourceDeleted'
         400:
           $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/ForbiddenOperation'
         404:
           $ref: '#/components/responses/ResourceNotFound'
     parameters:


### PR DESCRIPTION
When tenancy support was added to the v3 configuration endpoints, it added new possible error responses to the endpoints -- 400 in the case that the tenant did not exist, and 403 in the case that the requested operation is forbidden. This PR updates the API spec to reflect that.