### PR TITLE
CASMCMS-9505: Reject multi-tenancy for unsupported API version /v2/configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CASMCMS-9505: Reject multi-tenancy for unsupported API version /v2/configurations.
+
 ## [1.27.0] - 07/03/2025
 ### Changed
 - Use `redis` `RESP3` protocol

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -37,7 +37,7 @@ from cray.cfs.api.controllers import sources
 from cray.cfs.api.k8s_utils import get_configmap as get_kubernetes_configmap
 from cray.cfs.api.vault_utils import get_secret as get_vault_secret
 from cray.cfs.api.models.v2_configuration import V2Configuration # noqa: E501
-from cray.cfs.utils.multitenancy import get_tenant_from_header, reject_invalid_tenant
+from cray.cfs.utils.multitenancy import get_tenant_from_header, reject_invalid_tenant, reject_tenancy_for_unsupported_api
 
 LOGGER = logging.getLogger('cray.cfs.api.controllers.configurations')
 DB = dbutils.get_wrapper(db='configurations')
@@ -158,6 +158,7 @@ def _config_in_use(config_name: str) -> bool:
     return False
 
 @dbutils.redis_error_handler
+@reject_tenancy_for_unsupported_api
 def get_configuration_v2(configuration_id):
     """Used by the GET /configurations/{configuration_id} API operation"""
     LOGGER.debug("GET /configurations/id invoked get_configuration")
@@ -185,6 +186,7 @@ def get_configuration_v3(configuration_id):
 
 
 @dbutils.redis_error_handler
+@reject_tenancy_for_unsupported_api
 def put_configuration_v2(configuration_id):
     """Used by the PUT /configurations/{configuration_id} API operation"""
     LOGGER.debug("PUT /configurations/id invoked put_configuration")
@@ -301,6 +303,7 @@ def put_configuration_v3(configuration_id, drop_branches=False):
 
 
 @dbutils.redis_error_handler
+@reject_tenancy_for_unsupported_api
 def patch_configuration_v2(configuration_id):
     """Used by the PATCH /configurations/{configuration_id} API operation"""
     LOGGER.debug("PATCHv2 /configurations/id invoked put_configuration")
@@ -346,6 +349,7 @@ def patch_configuration_v3(configuration_id):
 
 
 @dbutils.redis_error_handler
+@reject_tenancy_for_unsupported_api
 def delete_configuration_v2(configuration_id):
     """Used by the DELETE /configurations/{configuration_id} API operation"""
     LOGGER.debug("DELETE /configurations/id invoked delete_configuration")

--- a/src/server/cray/cfs/utils/multitenancy.py
+++ b/src/server/cray/cfs/utils/multitenancy.py
@@ -92,3 +92,19 @@ def reject_invalid_tenant(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+def reject_tenancy_for_unsupported_api(func):
+    """Decorator for rejecting requests with a tenant header for unsupported APIs"""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        tenant = get_tenant_from_header()
+        if tenant:
+            LOGGER.debug("Rejecting request with tenant header for unsupported API")
+            return connexion.problem(
+                status=400,
+                title="Unsupported API",
+                detail=str("This API does not support multi-tenancy"))
+        return func(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
## Summary and Scope

CASMCMS-9505: Reject multi-tenancy for unsupported API version /v2/configurations

Reject requests to endpoints if there is a tenant specified and the endpoint doesn't support multitenancy. 

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

