### PR TITLE
CASMCMS-9553: Do not yield missing entries from DBWrapper.iter_values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - CASMCMS-9538: Fix race condition problems
+    - CASMCMS-9553: Make DBWrapper.iter_values smart enough to handle the case where
+      a DB entry is deleted while it is executing.
 
 ## [1.27.0] - 07/03/2025
 ### Changed

--- a/src/server/cray/cfs/api/dbutils.py
+++ b/src/server/cray/cfs/api/dbutils.py
@@ -102,7 +102,12 @@ class DBWrapper():
             all_keys = [k for k in all_keys if k > start_after_key]
         while all_keys:
             for datastr in self.client.mget(all_keys[:500]):
-                yield json.loads(datastr) if datastr else None
+                if not datastr:
+                    # If datastr is empty/None, that means that the entry was
+                    # deleted after the key was returned by the mget call.
+                    # In that case, we just skip it.
+                    continue
+                yield json.loads(datastr)
             all_keys = all_keys[500:]
 
     def get_all(self, limit=0, after_id=None, data_filters=None):


### PR DESCRIPTION
## Summary and Scope

This PR is deliberately not against the `develop` branch.
I am going to work on CASMCMS-9538 incrementally, using self-contained subtasks, corresponding to Jiras like this one. Each PR will be adding to the `casmcms-9538` branch, and when we're ready, I'll merge that all into `develop`.

The main symptom reported in CASMCMS-9538 was that some CFS GET requests included null values in the list of resources. This was causing the SAT tests to intermittently fail. This PR will resolve that specific issue, but there are a number of other race conditions in the code, some of which could cause other problems for the SAT tests, or even for customers.

## Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9538
* https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9544

## Testing

Ongoing

## Risks and Mitigations

Low risk. BOS and CFS share a lot of the same code patterns, and this change was already made in the BOS repo (likely because the type annotations complained about the null value being returned when it didn't follow the API spec). Plus, it's easy to see that the callers of this method never are expecting null values. In fact, in earlier versions of CFS, this same issue resulted in exceptions being raised and 5xx responses. The reason this was never looked into or fixed is likely because any such API calls would succeed on retry in most cases, and unless this was being done deliberately as part of a race condition test, the cause of the problem would not be obvious.

## Pull Request Checklist

- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

