### PR TITLE
CASMCMS-9557: Add basic type annotations to dbutils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - CASMCMS-9553: Make DBWrapper.iter_values smart enough to handle the case where
       a DB entry is deleted while it is executing.
     - CASMCMS-9556: Consolidate duplicate DBWrapper code
+    - CASMCMS-9557: Add basic type annotations to dbutils
 
 ## [1.27.0] - 07/03/2025
 ### Changed


### PR DESCRIPTION
## Summary and Scope

This is another subtask that does not directly address the race conditions. However, I think it is important to do this for three reasons:

1. I am going to be adding to and modifying this module. When I add or change code, I generally type annotate it. If I don't do this for the rest of the code, it will leave it in a patchwork state. This will cause no problems at runtime (since type annotations do not affect runtime logic), but still isn't ideal from a readability point of view.

2. Possibly more importantly, I think these race conditions are more obvious after functions have been properly type annotated. It makes it obvious, for example, when a given function may return a None value. Callers to that function can then be sure to handle that case, rather than overlook it.

3. As noted in point 1, type annotations do not impact the runtime logic. So doing this is very low risk. And given that I do not plan to do this comprehensively, it is not a big investment of time. It will just make this module easier for future devs to understand.

It is also helpful that a lot of the code in dbutils is/was common with the corresponding code in the BOS repository, so I was able to borrow or modify a lot of the type hints from there.

In addition to the type annotations, this PR does some very minor linting (organizing imports better and splitting up long lines).

## Testing

On wasp I ran the `cmsdev` CFS tests, and my hacked-together race condition test to find None values in list commands. All of them passed.

## Risks and Mitigations

Very low risk. No runtime changes.

## Pull Request Checklist

- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

