### PR TITLE
CASMCMS-9559: Add get_delete to DBWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       a DB entry is deleted while it is executing.
     - CASMCMS-9556: Consolidate duplicate DBWrapper code
     - CASMCMS-9557: Add basic type annotations to dbutils
+    - CASMCMS-9559: Add `get_delete` method to the DB wrapper
 
 ## [1.27.0] - 07/03/2025
 ### Changed

--- a/src/server/cray/cfs/api/controllers/sessions.py
+++ b/src/server/cray/cfs/api/controllers/sessions.py
@@ -227,12 +227,11 @@ def delete_session_v2(session_name):  # noqa: E501
     :rtype: None
     """
     LOGGER.debug("DELETE /v2/sessions/%s invoked delete_session_v2", session_name)
-    if session_name not in DB:
+    session = DB.get_delete(session_name)
+    if session is None:
         return connexion.problem(
             status=404, title="Session not found.",
             detail=f"Session {session_name} could not be found")
-    session = DB.get(session_name)
-    DB.delete(session_name)
     _kafka.produce(event_type='DELETE', data=session)
     return None, 204
 
@@ -249,12 +248,11 @@ def delete_session_v3(session_name):  # noqa: E501
     :rtype: None
     """
     LOGGER.debug("DELETE /v3/sessions/%s invoked delete_session_v3", session_name)
-    if session_name not in DB:
+    session = DB.get_delete(session_name)
+    if session is None:
         return connexion.problem(
             status=404, title="Session not found.",
             detail=f"Session {session_name} could not be found")
-    session = DB.get(session_name)
-    DB.delete(session_name)
     _kafka.produce(event_type='DELETE', data=session)
     return None, 204
 

--- a/src/server/cray/cfs/api/dbutils.py
+++ b/src/server/cray/cfs/api/dbutils.py
@@ -105,10 +105,15 @@ class DBWrapper:
     def get(self, key: DbKey) -> Optional[DbEntry]:
         """Get the data for the given key, or None if the entry does not exist."""
         datastr = self.client.get(key)
-        if not datastr:
-            return None
-        data = json.loads(datastr)
-        return data
+        return json.loads(datastr) if datastr else None
+
+    def get_delete(self, key: DbKey) -> Optional[DbEntry]:
+        """
+        Get the data for the given key from the database, and delete it from the DB.
+        Returns the data (or None if the entry does not exist).
+        """
+        datastr = self.client.getdel(key)
+        return json.loads(datastr) if datastr else None
 
     def get_keys(self, start_after_key: Optional[str] = None) -> list[str]:
         """


### PR DESCRIPTION
## Summary and Scope

Redis has an operation which atomically gets and deletes a DB entry. The session delete endpoint needs to use this in order to avoid a race condition where another thing deletes the session between the get and the delete. This PR adds this method to the DB wrapper, and then modifies the session delete endpoints to use it.

## Testing

I ran tests creating and deleting sessions on wasp, using these endpoints, and verified that they worked fine and no errors were logged in the pods.

## Risks and Mitigations

Low risk -- we already use this DB operation in BOS, and there is nothing tricky about it. The two cases where we are using it here are very simple and unlikely to produce unexpected behavior.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

