### PR TITLE
CASMCMS-9561: Consolidate back-end code for multi-session-delete endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - CASMCMS-9556: Consolidate duplicate DBWrapper code
     - CASMCMS-9557: Add basic type annotations to dbutils
     - CASMCMS-9559: Add `get_delete` method to the DB wrapper
+    - CASMCMS-9561: Consolidate back-end code for multi-session-delete endpoints
 
 ## [1.27.0] - 07/03/2025
 ### Changed

--- a/src/server/cray/cfs/api/controllers/sessions.py
+++ b/src/server/cray/cfs/api/controllers/sessions.py
@@ -27,9 +27,11 @@ from functools import partial
 import logging
 import re
 import shlex
+from typing import final, Optional, TypedDict
 from uuid import UUID
 
 import connexion
+from connexion.lifecycle import ConnexionResponse as CxResponse
 import dateutil
 
 from cray.cfs.api import dbutils
@@ -46,6 +48,16 @@ DB = dbutils.get_wrapper(db='sessions')
 CONFIG_DB = dbutils.get_wrapper(db='configurations')
 
 _kafka = None
+
+# Marked as final because we do not intend to subclass this. It doesn't really
+# matter at this point, but if type checking is ever properly added, this helps
+# the type checker.
+@final
+class SessionIdListDict(TypedDict):
+    """
+    Used for type hinting the v3 session endpoints which return ID list dicts
+    """
+    session_ids: list[str]
 
 
 def _init(topic='cfs-session-events'):
@@ -258,8 +270,13 @@ def delete_session_v3(session_name):  # noqa: E501
 
 
 @dbutils.redis_error_handler
-def delete_sessions_v2(age=None,  min_age=None, max_age=None,
-                       status=None, name_contains=None, succeeded=None, tags=None):
+def delete_sessions_v2(age: Optional[str] = None,
+                       min_age: Optional[str] = None,
+                       max_age: Optional[str] = None,
+                       status: Optional[str] = None,
+                       name_contains: Optional[str] = None,
+                       succeeded: Optional[str] = None,
+                       tags: Optional[str] = None) -> tuple[None, 204] | CxResponse:
     """Delete Config Framework Sessions
 
      # noqa: E501
@@ -282,35 +299,31 @@ def delete_sessions_v2(age=None,  min_age=None, max_age=None,
     :rtype: None
     """
     LOGGER.debug("DELETE /v2/sessions invoked delete_sessions_v2")
-    tag_list = []
-    if tags:
-        try:
-            tag_list = [tuple(tag.split('=')) for tag in tags.split(',')]
-            for tag in tag_list:
-                assert len(tag) == 2
-        except Exception as err:
-            return connexion.problem(
-                status=400, title="Error parsing the tags provided.",
-                detail=str(err))
-    try:
-        sessions_data, _ = _get_filtered_sessions(age=age, min_age=min_age, max_age=max_age,
-                                                  status=status, name_contains=name_contains,
-                                                  succeeded=succeeded, tag_list=tag_list)
-    except ParsingException as err:
-        return connexion.problem(
-            detail=str(err),
-            status=400,
-            title='Error parsing age field'
-        )
-    for session in sessions_data:
-        DB.delete(session['name'])
-        _kafka.produce(event_type='DELETE', data=session)
-    return None, 204
+    # This endpoint is the same as the v3 version except for what it returns when successful:
+    # the v3 endpoint returns 204 status and a dict containing the deleted IDs
+    # the v2 endpoint returns 200 status and None
+    #
+    # Because of this, both endpoints use a common function to do the actual work.
+    response, status_code = delete_sessions(age=age, min_age=min_age, max_age=max_age,
+                                           status=status, name_contains=name_contains,
+                                           succeeded=succeeded, tags=tags)
+    if status_code == 200:
+        # This means it was successful. The v2 endpoint returns None, 204 in this case.
+        return None, 204
+
+    # This means there was an error, in which case the v2 and v3 endpoints are the same in
+    # in terms of the response.
+    return response, status_code
 
 
 @dbutils.redis_error_handler
-def delete_sessions_v3(age=None,  min_age=None, max_age=None,
-                       status=None, name_contains=None, succeeded=None, tags=None):
+def delete_sessions_v3(age: Optional[str] = None,
+                       min_age: Optional[str] = None,
+                       max_age: Optional[str] = None,
+                       status: Optional[str] = None,
+                       name_contains: Optional[str] = None,
+                       succeeded: Optional[str] = None,
+                       tags: Optional[str] = None) -> tuple[SessionIdListDict, 200] | CxResponse:
     """Delete Config Framework Sessions
 
      # noqa: E501
@@ -330,9 +343,44 @@ def delete_sessions_v3(age=None,  min_age=None, max_age=None,
     :param tags: A filter on session tags
     :type tags: bool
 
-    :rtype: None
+    :rtype: dict { "session_ids": [ "list", "of", "session", "ids" ] } (if successful)
+    Otherwise returns a connexion.problem object
     """
     LOGGER.debug("DELETE /v3/sessions invoked delete_sessions_v3")
+    return delete_sessions(age=age, min_age=min_age, max_age=max_age,
+                          status=status, name_contains=name_contains,
+                          succeeded=succeeded, tags=tags)
+
+
+def delete_sessions(age: Optional[str],
+                    min_age: Optional[str],
+                    max_age: Optional[str],
+                    status: Optional[str],
+                    name_contains: Optional[str],
+                    succeeded: Optional[str],
+                    tags: Optional[str]) -> tuple[SessionIdListDict, 200] | CxResponse:
+    """Delete Config Framework Sessions
+
+     # noqa: E501
+
+    :param age: An age filter in the form 1d.
+    :type age: str
+    :param min_age: An age filter in the form 1d.
+    :type min_age: str
+    :param max_age: An age filter in the form 1d.
+    :type max_age: str
+    :param status: A session status filter
+    :type status: str
+    :param name_contains: A filter on session names
+    :type name_contains: str
+    :param succeeded: A filter on session success
+    :type succeeded: bool
+    :param tags: A filter on session tags
+    :type tags: bool
+
+    :rtype: dict { "session_ids": [ "list", "of", "session", "ids" ] } (if successful)
+    Otherwise returns a connexion.problem object
+    """
     tag_list = []
     if tags:
         try:


### PR DESCRIPTION
## Summary and Scope

The only true difference between the v2 and v3 endpoints for deleting multiple sessions is in what they return on success. When successful, the v2 endpoint returns a 204 status, and None. On the other hand, the v3 endpoint returns 200 and a list of the IDs that were deleted. Their error responses are identical.

They both accept the same parameters, and they both *should* delete the same set of sessions given the same inputs. I say should because due to how the v2 endpoint is implemented, it will only delete up to 1 "page" worth of sessions. This is actually a regression change from when the v3 paging code was introduced, and I am not aware of it being documented anywhere.

It is understood that some v2 endpoints did have breaking changes as a result of the paging addition. For example, when listing v2 sessions, previously it would list as many as there were, but now it will give an error if the response would include more sessions than the default page size. 

The behavior with the v2 delete_all endpoint is worse for two reasons:
1. There is no reason for it. The paging limitation on the v2 get sessions endpoint makes sense, because it is returning those objects, and the point of the paging feature was to avoid problems related to very large responses. However, in the case of the delete endpoint, no data is being sent back like this. So there's no reason for the limitation.
2. The behavior is inconsistent with how the v2 get sessions endpoint behaves. As mentioned, that endpoint will return an error when it runs up against the paging limitation. The v2 delete_all endpoint just deletes up to 1 page's worth of sessions and returns a success, with no indication of whether or not there were additional sessions that it did not delete due to this limitation.

Just on the basis of the above, it would be worth addressing this, although given that this issue has been in the code since CFS v3 was introduced, it would be hard to argue that it has been a critical problem. The motivation for addressing it with this PR is because in order to fix one of the race condition bugs, the v2 endpoint needs to be modified to use the same DB.delete_all method that the v3 endpoint uses. This will enable me to address the race condition bug, while also addressing the above issues. As additional side benefits, this will also reduce duplicated code, and will improve performance of the v2 endpoint.

(in addition to consolidating the code used for these two endpoints, I also added basic type annotations for them).

## Testing

I tested this on wasp. I first verified that (without my changes) when I deleted using the v2 multi-delete endpoint, it would only delete a maximum of the default page size. I then applied my changes, and verified that both the v2 and v3 multi-delete endpoints would delete all matching sessions, regardless of page size. I also verified that they each returned the correct response format for the given CFS version. I also ran the `cmsdev` CFS tests, for good measure, and checked the CFS pod logs to make sure no errors or warnings were logged.

## Risks and Mitigations

Fairly low risk. The code logic is very similar even before this PR. My testing should reveal if there are any issues.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

