### PR TITLE
CASMCMS-9562: Consolidate back-end code for multi-component-patch endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - CASMCMS-9557: Add basic type annotations to dbutils
     - CASMCMS-9559: Add `get_delete` method to the DB wrapper
     - CASMCMS-9561: Consolidate back-end code for multi-session-delete endpoints
+    - CASMCMS-9562: Consolidate back-end code for multi-component-patch endpoints
 
 ## [1.27.0] - 07/03/2025
 ### Changed

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -372,6 +372,11 @@ def patch_v2_components_dict(data: V2ComponentsUpdate) -> V2PatchComponentsRespo
                                config_name=filters.get("configName", None), tag_list=tag_list)
 
     v2_patch = data.get("patch", {})
+    # Remove the id field if it exists (if it does not, do nothing).
+    # The pop call will raise a KeyError if the field does not exist, unless
+    # we specify a default return value. In this case, we do not care about
+    # the return value, but we specify a default of None purely to avoid
+    # the KeyError being raised.
     v2_patch.pop("id", None)
     v3_patch = dbutils.convert_data_from_v2(v2_patch, V2Component)
     v3_patch = _set_auto_fields(v3_patch)
@@ -454,6 +459,11 @@ def patch_v3_components_dict(data: V3ComponentsUpdate) -> V3PatchComponentsRespo
                                enabled=filters.get("enabled", None),
                                config_name=filters.get("config_name", None), tag_list=tag_list)
     patch = data.get("patch", {})
+    # Remove the id field if it exists (if it does not, do nothing).
+    # The pop call will raise a KeyError if the field does not exist, unless
+    # we specify a default return value. In this case, we do not care about
+    # the return value, but we specify a default of None purely to avoid
+    # the KeyError being raised.
     patch.pop("id", None)
     patch = _set_auto_fields(patch)
     component_ids = DB.patch_all(component_filter, patch, _update_handler)

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -25,8 +25,10 @@ from copy import deepcopy
 from datetime import datetime
 from functools import partial
 import logging
+from typing import final, Literal, NewType, Optional, TypedDict
 
 import connexion
+from connexion.lifecycle import ConnexionResponse as CxResponse
 
 from cray.cfs.api import dbutils
 from cray.cfs.api.k8s_utils import get_ara_ui_url
@@ -51,6 +53,62 @@ STATUS = {
     STATUS_CONFIGURED: 'configured',
     STATUS_DEPRECATED: 'config_deprecated',
 }
+
+# For rudimentary type annotation
+
+# Marked as final because we do not intend to subclass this. It doesn't really
+# matter at this point, but if type checking is ever properly added, this helps
+# the type checker.
+@final
+class ComponentIdListDict(TypedDict):
+    """
+    Used for type hinting the v3 endpoints which return ID list dicts
+    """
+    component_ids: list[str]
+
+
+V2ComponentData = NewType("V2ComponentData", dbutils.JsonDict)
+V3ComponentData = NewType("V3ComponentData", dbutils.JsonDict)
+
+V3FilterStatus = Literal['unconfigured', 'pending', 'failed', 'configured', '']
+V2FilterStatus = Literal['unconfigured', 'pending', 'failed', 'configured']
+
+@final
+class V2ComponentsFilter(TypedDict, total=False):
+    """
+    total is False because all of these fields are optional (at least one
+    must be specified, but it doesn't matter which)
+    """
+    ids: str
+    status: V2FilterStatus
+    enabled: bool
+    configName: str
+    tags: str
+
+
+@final
+class V3ComponentsFilter(TypedDict, total=False):
+    """
+    total is False because all of these fields are optional (at least one
+    must be specified, but it doesn't matter which)
+    """
+    ids: str
+    status: V3FilterStatus
+    enabled: bool
+    config_name: str
+    tags: str
+
+
+@final
+class V2ComponentsUpdate(TypedDict):
+    patch: V2ComponentData
+    filters: V2ComponentsFilter
+
+
+@final
+class V3ComponentsUpdate(TypedDict):
+    patch: V3ComponentData
+    filters: V3ComponentsFilter
 
 
 @dbutils.redis_error_handler
@@ -168,8 +226,14 @@ def get_components_data(id_list=None, status_list=None, enabled=None, config_nam
     return component_data_page, next_page_exists
 
 
-def _component_filter(component_data, config_details, configs,
-                      id_list, status_list, enabled, config_name, tag_list):
+def _component_filter(component_data: V3ComponentData,
+                      config_details: Optional[bool],
+                      configs: configurations.Configurations,
+                      id_list: list[str],
+                      status_list: list[V3FilterStatus],
+                      enabled: Optional[bool],
+                      config_name: Optional[str],
+                      tag_list: list[str]) -> bool:
     # Before bothering to set status, check the filters which do not require it.
     if id_list and not component_data.get("id") in id_list:
         return False
@@ -233,7 +297,7 @@ def put_components_v3():
 
 
 @dbutils.redis_error_handler
-def patch_components_v2():
+def patch_components_v2() -> tuple[list[V2ComponentData], Literal[200]] | CxResponse:
     """Used by the PATCH /components API operation"""
     LOGGER.debug("PATCH /v2/components invoked patch_components_v2")
     data = connexion.request.get_json()
@@ -246,7 +310,9 @@ def patch_components_v2():
        detail=f"Unexpected data type {type(data)}")
 
 
-def patch_v2_components_list(data):
+def patch_v2_components_list(
+    data: list[V2ComponentData]
+) -> tuple[list[V2ComponentData], Literal[200]] | CxResponse:
     try:
         components = []
         for component_data in data:
@@ -269,7 +335,9 @@ def patch_v2_components_list(data):
     return response, 200
 
 
-def patch_v2_components_dict(data):
+def patch_v2_components_dict(
+    data: V2ComponentsUpdate
+) -> tuple[list[V2ComponentData], Literal[200]] | CxResponse:
     filters = data.get("filters", {})
     id_list = []
     status_list = []
@@ -298,36 +366,25 @@ def patch_v2_components_dict(data):
                 status=400, title="Error parsing the tags provided.",
                 detail=str(err))
 
-    components = []
-    if id_list:
-        for component_id in id_list:
-            component_data = DB.get(component_id)
-            if component_data:
-                components.append(component_data)
-    else:
-        # On large scale systems, this response may be too large
-        # use v3 for smaller responses
-        components = DB.get_all()[0]
-
-    response = []
-    patch = data.get("patch", {})
-    patch.pop("id", None)
-    patch = dbutils.convert_data_from_v2(patch, V2Component)
-    patch = _set_auto_fields(patch)
     configs = configurations.Configurations()
     component_filter = partial(_component_filter, config_details=False, configs=configs,
-                               id_list=[], status_list=status_list,
+                               id_list=id_list, status_list=status_list,
                                enabled=filters.get("enabled", None),
-                               config_name=filters.get("config_name", None), tag_list=tag_list)
-    for component_data in components:
-        if component_filter(component_data):
-            response_data = DB.patch(component_data["id"], patch, _update_handler)
-            response.append(convert_component_to_v2(response_data))
+                               config_name=filters.get("configName", None), tag_list=tag_list)
+
+    v2_patch = data.get("patch", {})
+    v2_patch.pop("id", None)
+    v3_patch = dbutils.convert_data_from_v2(v2_patch, V2Component)
+    v3_patch = _set_auto_fields(v3_patch)
+
+    response = []
+    for _, v3_patched_comp in DB.patch_all_entries(component_filter, v3_patch, _update_handler):
+        response.append(convert_component_to_v2(v3_patched_comp))
     return response, 200
 
 
 @dbutils.redis_error_handler
-def patch_components_v3():
+def patch_components_v3() -> tuple[ComponentIdListDict, Literal[200]] | CxResponse:
     """Used by the PATCH /components API operation"""
     LOGGER.debug("PATCH /v3/components invoked patch_components_v3")
     data = connexion.request.get_json()
@@ -340,7 +397,9 @@ def patch_components_v3():
        detail=f"Unexpected data type {type(data)}")
 
 
-def patch_v3_components_list(data):
+def patch_v3_components_list(
+    data: list[V3ComponentData]
+) -> tuple[ComponentIdListDict, Literal[200]] | CxResponse:
     try:
         components = []
         for component_data in data:
@@ -363,7 +422,9 @@ def patch_v3_components_list(data):
     return response, 200
 
 
-def patch_v3_components_dict(data):
+def patch_v3_components_dict(
+    data: V3ComponentsUpdate
+) -> tuple[ComponentIdListDict, Literal[200]] | CxResponse:
     filters = data.get("filters", {})
     id_list = []
     status_list = []
@@ -691,14 +752,14 @@ def _state_append_handler(data):
     return data
 
 
-def convert_component_to_v2(data):
+def convert_component_to_v2(data: V3ComponentData) -> V2ComponentData:
     converted_state = [_convert_component_layer_to_v2(layer) for layer in data["state"]]
     data["state"] = converted_state
     data = dbutils.convert_data_to_v2(data, V2Component)
     return data
 
 
-def convert_component_to_v3(data):
+def convert_component_to_v3(data: V2ComponentData) -> V3ComponentData:
     data = dbutils.convert_data_from_v2(data, V2Component)
     converted_state = [_convert_component_layer_to_v3(layer) for layer in data["state"]]
     data["state"] = converted_state

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -110,6 +110,9 @@ class V3ComponentsUpdate(TypedDict):
     patch: V3ComponentData
     filters: V3ComponentsFilter
 
+type V2PatchComponentsResponse = tuple[list[V2ComponentData], Literal[200]] | CxResponse
+type V3PatchComponentsResponse = tuple[ComponentIdListDict, Literal[200]] | CxResponse
+
 
 @dbutils.redis_error_handler
 def get_components_v2(ids="", status="", enabled=None, config_name="", config_details=False,
@@ -297,7 +300,7 @@ def put_components_v3():
 
 
 @dbutils.redis_error_handler
-def patch_components_v2() -> tuple[list[V2ComponentData], Literal[200]] | CxResponse:
+def patch_components_v2() -> V2PatchComponentsResponse:
     """Used by the PATCH /components API operation"""
     LOGGER.debug("PATCH /v2/components invoked patch_components_v2")
     data = connexion.request.get_json()
@@ -310,9 +313,7 @@ def patch_components_v2() -> tuple[list[V2ComponentData], Literal[200]] | CxResp
        detail=f"Unexpected data type {type(data)}")
 
 
-def patch_v2_components_list(
-    data: list[V2ComponentData]
-) -> tuple[list[V2ComponentData], Literal[200]] | CxResponse:
+def patch_v2_components_list(data: list[V2ComponentData]) -> V2PatchComponentsResponse:
     try:
         components = []
         for component_data in data:
@@ -335,9 +336,7 @@ def patch_v2_components_list(
     return response, 200
 
 
-def patch_v2_components_dict(
-    data: V2ComponentsUpdate
-) -> tuple[list[V2ComponentData], Literal[200]] | CxResponse:
+def patch_v2_components_dict(data: V2ComponentsUpdate) -> V2PatchComponentsResponse:
     filters = data.get("filters", {})
     id_list = []
     status_list = []
@@ -384,7 +383,7 @@ def patch_v2_components_dict(
 
 
 @dbutils.redis_error_handler
-def patch_components_v3() -> tuple[ComponentIdListDict, Literal[200]] | CxResponse:
+def patch_components_v3() -> V3PatchComponentsResponse:
     """Used by the PATCH /components API operation"""
     LOGGER.debug("PATCH /v3/components invoked patch_components_v3")
     data = connexion.request.get_json()
@@ -397,9 +396,7 @@ def patch_components_v3() -> tuple[ComponentIdListDict, Literal[200]] | CxRespon
        detail=f"Unexpected data type {type(data)}")
 
 
-def patch_v3_components_list(
-    data: list[V3ComponentData]
-) -> tuple[ComponentIdListDict, Literal[200]] | CxResponse:
+def patch_v3_components_list(data: list[V3ComponentData]) -> V3PatchComponentsResponse:
     try:
         components = []
         for component_data in data:
@@ -422,9 +419,7 @@ def patch_v3_components_list(
     return response, 200
 
 
-def patch_v3_components_dict(
-    data: V3ComponentsUpdate
-) -> tuple[ComponentIdListDict, Literal[200]] | CxResponse:
+def patch_v3_components_dict(data: V3ComponentsUpdate) -> V3PatchComponentsResponse:
     filters = data.get("filters", {})
     id_list = []
     status_list = []

--- a/src/server/cray/cfs/api/controllers/configurations.py
+++ b/src/server/cray/cfs/api/controllers/configurations.py
@@ -305,6 +305,11 @@ def put_configuration_v3(configuration_id, drop_branches=False):
 
     if drop_branches:
         for layer in iter_layers(data, include_additional_inventory=True):
+            # Remove the branch field if it exists (if it does not, do nothing).
+            # The pop call will raise a KeyError if the field does not exist, unless
+            # we specify a default return value. In this case, we do not care about
+            # the return value, but we specify a default of None purely to avoid
+            # the KeyError being raised.
             layer.pop("branch", None)
 
     data['name'] = configuration_id


### PR DESCRIPTION
## Summary and Scope

This does not directly address a race condition, but the current implementation of the CFS v2 multi-component patch endpoint is going to make it more difficult to fix their race condition issues.

This PR refactors `dbutils` so that most of the `patch_all` logic moves into the new `patch_all_entries` generator method (and the `patch_all` method just calls it). The reason for this is that the `patch_all_entries` generator yields both the patched entry and its DB key (which is the CFS ID of the object). For V3 multi-patch, it only cares about returning the ID, but for V2, it wants to return the entire patched entry. Making this change in `dbutils` then enables the V2 `components_dict` function to use similar logic to the V3 `components_dict` function, only using the new DB generator method instead of the `patch_all` method.

To be clear, this change does not change the results of calling these endpoints, or the data they return. It only changes how it is done internally.

> Note that this PR only deals with the dict-style multi-component patches. The endpoint also supports a list-style patch, but that will require a different PR. This PR does not change anything about how those are handled.

In addition to making the above changes, I also added some basic type annotations to the functions I was working with in the components controller module. They will have no runtime impact, but hopefully will be helpful to anyone trying to understand the code.

## Testing

I tested on wasp. I ran `cmsdev` CFS tests, and I also used the dict-style multi-component patch with both V2 and V3. I validated that the patches were correctly applied, that the API response was correct for the given CFS version, and that no errors or warnings were logged in the CFS pods during this.

## Risks and Mitigations

It should be easy to conduct sufficient tests to identify problems if they exist. Fairly low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

