### PR TITLE
CASMCMS-9564: Create DBNoEntryError and DBTooBusyError exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - CASMCMS-9538: Fix race condition problems
     - CASMCMS-9553: Make DBWrapper.iter_values smart enough to handle the case where
-      a DB entry is deleted while it is executing.
+      a DB entry is deleted while it is executing
     - CASMCMS-9556: Consolidate duplicate DBWrapper code
     - CASMCMS-9557: Add basic type annotations to dbutils
     - CASMCMS-9559: Add `get_delete` method to the DB wrapper
     - CASMCMS-9561: Consolidate back-end code for multi-session-delete endpoints
     - CASMCMS-9562: Consolidate back-end code for multi-component-patch endpoints
+    - CASMCMS-9564: Create `DBNoEntryError` and `DBTooBusyError` exceptions
 
 ## [1.27.0] - 07/03/2025
 ### Changed


### PR DESCRIPTION
## Summary and Scope

This PR defines two new database-related exceptions for CFS, and adds helper methods in the `DBWrapper` class to create them for that particular database. This PR does not yet make any use of these exceptions. Other than a minor refactoring of how the `DBWrapper` class is initialized, this PR does not change the current CFS logic at all, and is functionally transparent.

I separated this into its own PR because the PR where I am going to make use of them is going to involve several things, and I wanted to try to focus it as much as possible.

The `DBNoEntryError` exception will be what the DB methods raise in a case where an entry does not exist, but the caller expected it to. Currently all of that logic is happening in the controller methods, but that leads to race condition problems (since if the controller checks for the existence of an entry, that doesn't mean the entry will still exist at the time the DB code is run).

The `DBTooBusyError` exception is created to handle a specific situation that can arise when dealing with race conditions. There are two general ways we can deal with race conditions in Redis:
1. Locking
2. Watch/execute pipelines.

The first one is pretty self-explanatory -- any method that is going to change data in the DB first must get the lock. This absolutely resolves race conditions, but it also adds overhead to every DB write, even though most DB writes don't happen at the same time, and even for those that do, many of them are writes to different keys where there would be no conflict. (You could also add locks for specific keys, but then you could end up in deadlock situations where two different methods are holding locks the other one needs).

The second one basically lets you first tell Redis the set of keys that you're going to be working on. Then you set up whatever DB commands you plan to run, and then you tell Redis to execute it. If any of the keys you are watching have changed in the meantime, it will raise an exception, and you can catch that and retry (or do whatever you like). Otherwise, it executes your entire pipeline atomically (so no other callers can interfere). This handles, for example, the race condition where two different DB callers are trying to patch the same CFS component. Maybe one is trying to set the error count to 0, and the other is trying to disable the component. Under current CFS, if the timing was right, you could end up with a case where both of the calls succeeded, but the final state of the DB only has one of the two applied. This watch/execute method avoids that. However, it then forces you to decide things like -- how many times should I retry this? And if the answer isn't "forever", then what do I tell the caller? This is what the `DBTooBusyError` exception covers.

When I make my later changes that start using this exception, we can see first hand how often (if at all) these exceptions get raised. I am hoping that if we set acceptable retries, that these should realistically never happen. But if that's not the case, we can revisit the locking idea.

## Testing

Performed regression testing on wasp to make sure the changes did not break anything. Just starting the CFS service calls the `DBWrapper` constructor multiple times.

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

