### PR TITLE
CASMCMS-9568: Update DBWrapper get calls to use DBNoEntryError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - CASMCMS-9562: Consolidate back-end code for multi-component-patch endpoints
     - CASMCMS-9564: Create `DBNoEntryError` and `DBTooBusyError` exceptions
     - CASMCMS-9554: Update DBWrapper `delete`/`get_delete` calls to use `DBNoEntryError`
+    - CASMCMS-9568: Update DBWrapper `get` calls to use `DBNoEntryError`
 
 ## [1.27.0] - 07/03/2025
 ### Changed

--- a/src/server/cray/cfs/api/controllers/components.py
+++ b/src/server/cray/cfs/api/controllers/components.py
@@ -110,11 +110,15 @@ class V3ComponentsUpdate(TypedDict):
     patch: V3ComponentData
     filters: V3ComponentsFilter
 
-type V2PatchComponentsResponse = tuple[list[V2ComponentData], Literal[200]] | CxResponse
-type V3PatchComponentsResponse = tuple[ComponentIdListDict, Literal[200]] | CxResponse
+type V2GetComponentResponse = tuple[V2ComponentData, Literal[200]] | CxResponse
+type V3GetComponentResponse = tuple[V3ComponentData, Literal[200]] | CxResponse
 
 # The response format for the delete component endpoint is the same for v2 and v3
 type DeleteComponentResponse = tuple[None, Literal[204]] | CxResponse
+
+type V2PatchComponentsResponse = tuple[list[V2ComponentData], Literal[200]] | CxResponse
+type V3PatchComponentsResponse = tuple[ComponentIdListDict, Literal[200]] | CxResponse
+
 
 @dbutils.redis_error_handler
 def get_components_v2(ids="", status="", enabled=None, config_name="", config_details=False,
@@ -474,14 +478,16 @@ def patch_v3_components_dict(data: V3ComponentsUpdate) -> V3PatchComponentsRespo
 
 
 @dbutils.redis_error_handler
-def get_component_v2(component_id, config_details=False):
+def get_component_v2(component_id: str, config_details: bool=False) -> V2GetComponentResponse:
     """Used by the GET /components/{component_id} API operation"""
     LOGGER.debug("GET /v2/components/%s invoked get_component_v2", component_id)
-    if component_id not in DB:
+    try:
+        component = DB.get(component_id)
+    except dbutils.DBNoEntryError as err:
+        LOGGER.debug(err)
         return connexion.problem(
             status=404, title="Component not found.",
             detail=f"Component {component_id} could not be found")
-    component = DB.get(component_id)
     configs = configurations.Configurations()
     component = _set_status(component, configs, config_details)
     component = convert_component_to_v2(component)
@@ -489,14 +495,19 @@ def get_component_v2(component_id, config_details=False):
 
 
 @dbutils.redis_error_handler
-def get_component_v3(component_id, state_details=False, config_details=False):
+def get_component_v3(component_id: str,
+                     state_details: bool=False,
+                     config_details: bool=False) -> V3GetComponentResponse:
     """Used by the GET /components/{component_id} API operation"""
     LOGGER.debug("GET /v3/components/%s invoked get_component_v3", component_id)
-    if component_id not in DB:
+    try:
+        component = DB.get(component_id)
+    except dbutils.DBNoEntryError as err:
+        LOGGER.debug(err)
         return connexion.problem(
             status=404, title="Component not found.",
             detail=f"Component {component_id} could not be found")
-    component = DB.get(component_id)
+
     configs = configurations.Configurations()
     component = _set_status(component, configs, config_details)
     component = _set_link(component)

--- a/src/server/cray/cfs/api/controllers/options.py
+++ b/src/server/cray/cfs/api/controllers/options.py
@@ -55,7 +55,11 @@ def _init():
 
 
 def cleanup_old_options():
-    data = DB.get(OPTIONS_KEY)
+    try:
+        data = DB.get(OPTIONS_KEY)
+    except dbutils.DBNoEntryError as err:
+        LOGGER.debug(err)
+        return
     if not data:
         return
     # Cleanup
@@ -82,7 +86,12 @@ def get_options_v3():
 
 
 def get_options_data():
-    return _check_defaults(DB.get(OPTIONS_KEY))
+    try:
+        current_data = DB.get(OPTIONS_KEY)
+    except dbutils.DBNoEntryError as err:
+        LOGGER.debug(err)
+        current_data = None
+    return _check_defaults(current_data)
 
 
 def _check_defaults(data):

--- a/src/server/cray/cfs/api/controllers/sessions.py
+++ b/src/server/cray/cfs/api/controllers/sessions.py
@@ -27,7 +27,7 @@ from functools import partial
 import logging
 import re
 import shlex
-from typing import final, Literal, Optional, TypedDict
+from typing import final, Literal, NewType, Optional, TypedDict
 from uuid import UUID
 
 import connexion
@@ -51,6 +51,12 @@ _kafka = None
 
 # For rudimentary type annotations
 
+V2SessionData = NewType("V2SessionData", dbutils.JsonDict)
+V3SessionData = NewType("V3SessionData", dbutils.JsonDict)
+
+V2SessionPatchData = NewType("V2SessionPatchData", dbutils.JsonDict)
+V3SessionPatchData = NewType("V3SessionPatchData", dbutils.JsonDict)
+
 # Marked as final because we do not intend to subclass this. It doesn't really
 # matter at this point, but if type checking is ever properly added, this helps
 # the type checker.
@@ -65,9 +71,15 @@ class SessionIdListDict(TypedDict):
 # The response format for the delete session endpoint is the same for v2 and v3
 type DeleteSessionResponse = tuple[None, Literal[204]] | CxResponse
 
+type V2GetSessionResponse = tuple[V2SessionData, Literal[200]] | CxResponse
+type V3GetSessionResponse = tuple[V3SessionData, Literal[200]] | CxResponse
+
 type V2DeleteSessionsResponse = tuple[None, Literal[204]] | CxResponse
 type V3DeleteSessionsResponse = tuple[SessionIdListDict, Literal[200]] | CxResponse
 
+# Although it does not conform to convention, the successful patch requests return 200 status
+type V2PatchSessionResponse = tuple[V2SessionData, Literal[200]] | CxResponse
+type V3PatchSessionResponse = tuple[V3SessionData, Literal[200]] | CxResponse
 
 def _init(topic='cfs-session-events'):
     """ Initialize the kafka producer information """
@@ -422,7 +434,7 @@ def delete_sessions(age: Optional[str],
 
 
 @dbutils.redis_error_handler
-def get_session_v2(session_name):  # noqa: E501
+def get_session_v2(session_name: str) -> V2GetSessionResponse:  # noqa: E501
     """Config Framework Session Details
 
      # noqa: E501
@@ -433,15 +445,18 @@ def get_session_v2(session_name):  # noqa: E501
     :rtype: V2Session
     """
     LOGGER.debug("GET /v2/sessions/%s invoked get_session_v2", session_name)
-    if session_name not in DB:
+    try:
+        v3_session_data = DB.get(session_name)
+    except dbutils.DBNoEntryError as err:
+        LOGGER.debug(err)
         return connexion.problem(
             status=404, title="Session not found.",
             detail=f"Session {session_name} could not be found")
-    return convert_session_to_v2(DB.get(session_name)), 200
+    return convert_session_to_v2(v3_session_data), 200
 
 
 @dbutils.redis_error_handler
-def get_session_v3(session_name):  # noqa: E501
+def get_session_v3(session_name: str) -> V3GetSessionResponse:  # noqa: E501
     """Config Framework Session Details
 
      # noqa: E501
@@ -452,13 +467,15 @@ def get_session_v3(session_name):  # noqa: E501
     :rtype: V3Session
     """
     LOGGER.debug("GET /v3/sessions/%s invoked get_session_v3", session_name)
-    if session_name not in DB:
+    try:
+        v3_session_data = DB.get(session_name)
+    except dbutils.DBNoEntryError as err:
+        LOGGER.debug(err)
         return connexion.problem(
             status=404, title="Session not found.",
             detail=f"Session {session_name} could not be found")
-    session_data = DB.get(session_name)
-    _set_link(session_data)
-    return session_data, 200
+    _set_link(v3_session_data)
+    return v3_session_data, 200
 
 
 @dbutils.redis_error_handler
@@ -526,7 +543,7 @@ def get_sessions_v3(age=None, min_age=None, max_age=None, status=None, name_cont
 
 
 @dbutils.redis_error_handler
-def patch_session_v2(session_name):
+def patch_session_v2(session_name: str) -> V2PatchSessionResponse:
     """Update a Config Framework Session
 
     Updates a new V2Session # noqa: E501
@@ -535,25 +552,26 @@ def patch_session_v2(session_name):
     """
     LOGGER.debug("PATCH /v2/sessions/%s invoked patch_session_v2", session_name)
     try:
-        data = connexion.request.get_json()
-        if any(key != 'status' for key in data):
+        v2_patch_data = connexion.request.get_json()
+        if any(key != 'status' for key in v2_patch_data):
             raise Exception('Only status can be updated after session creation')
     except Exception as err:
         return connexion.problem(
             status=400, title="Bad Request",
             detail=str(err))
-
-    if session_name not in DB:
+    v3_patch_data = dbutils.convert_data_from_v2(v2_patch_data, V2Session)
+    try:
+        v3_session_data = _patch_session(session_name, v3_patch_data)
+    except dbutils.DBNoEntryError as err:
+        LOGGER.debug(err)
         return connexion.problem(
             status=404, title="Session not found.",
             detail=f"Session {session_name} could not be found")
-    data = dbutils.convert_data_from_v2(data, V2Session)
-    response_data = _patch_session(session_name, data)
-    return convert_session_to_v2(response_data), 200
+    return convert_session_to_v2(v3_session_data), 200
 
 
 @dbutils.redis_error_handler
-def patch_session_v3(session_name):
+def patch_session_v3(session_name: str) -> V3PatchSessionResponse:
     """Update a Config Framework Session
 
     Updates a new V3Session # noqa: E501
@@ -562,20 +580,21 @@ def patch_session_v3(session_name):
     """
     LOGGER.debug("PATCH /v3/sessions/%s invoked patch_session_v3", session_name)
     try:
-        data = connexion.request.get_json()
-        if any(key != 'status' for key in data):
+        v3_patch_data = connexion.request.get_json()
+        if any(key != 'status' for key in v3_patch_data):
             raise Exception('Only status can be updated after session creation')
     except Exception as err:
         return connexion.problem(
             status=400, title="Bad Request",
             detail=str(err))
-
-    if session_name not in DB:
+    try:
+        v3_session_data = _patch_session(session_name, v3_patch_data)
+    except dbutils.DBNoEntryError as err:
+        LOGGER.debug(err)
         return connexion.problem(
             status=404, title="Session not found.",
             detail=f"Session {session_name} could not be found")
-    response_data = _patch_session(session_name, data)
-    return response_data, 200
+    return v3_session_data, 200
 
 
 # Some status fields should not progress backwards.
@@ -586,7 +605,13 @@ STATUS_ORDERING = {
 }
 
 
-def _patch_session(session_name, new_data):
+def _patch_session(session_name: str, new_data: V3SessionPatchData) -> V3SessionData:
+    """
+    Retrieves the session data from the database.
+    Raises dbutils.DBNoEntryError if the entry to be patched is not in the database
+    Otherwise, applies the new_data patch to it, writes it back to the database,
+    and returns the updated session data.
+    """
     data = DB.get(session_name)
     status = data['status']
     artifacts = status['artifacts']
@@ -809,12 +834,12 @@ def _set_link(data):
     return data
 
 
-def convert_session_to_v2(data):
+def convert_session_to_v2(data: V3SessionData) -> V2SessionData:
     data = dbutils.convert_data_to_v2(data, V2Session)
     return data
 
 
-def convert_session_to_v3(data):
+def convert_session_to_v3(data: V2SessionData) -> V3SessionData:
     data = dbutils.convert_data_from_v2(data, V2Session)
     return data
 


### PR DESCRIPTION
## Summary and Scope

This continues the work started in https://github.com/Cray-HPE/config-framework-service/pull/200, this time for the `DB.get` method.

This PR modifies that method so that it now raises `DBNoEntryError` when the entry does not exist (instead of returning None). 
And of course it modifies all callers of the method, to make sure they correctly handle the exception.

In addition, the DB.patch and DB.put methods are modified so that they do not call DB.get to produce their return values. Instead, they just return the data was written to the database. The calling code clearly does not assume that DB.put or DB.patch will ever return None (which is what currently would happen if an entry was deleted immediately after being PUT or PATCHed). So this change seems to be in line with what the original code intended (and avoids the need for DB.patch and DB.put to handle the new exception)/

Finally, as with all of these PRs, some basic type annotations are added to the methods and functions being modified.

## Testing

Underway

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

